### PR TITLE
Web: focus, cleanup and view size

### DIFF
--- a/packages/replay-web/src/__tests__/inputs.test.ts
+++ b/packages/replay-web/src/__tests__/inputs.test.ts
@@ -161,7 +161,7 @@ test("Pointer clicks and move", async () => {
     0
   );
 
-  movePointer(300, 300);
+  movePointer(150, 150);
 
   mockTime.nextFrame();
 
@@ -169,14 +169,14 @@ test("Pointer clicks and move", async () => {
     [
       "pointerPressed: true",
       "pointerJustPressed: false",
-      "pointerX: 200",
-      "pointerY: -200",
+      "pointerX: 50",
+      "pointerY: -50",
     ].join(),
     0,
     0
   );
 
-  releasePointer(400, 400);
+  releasePointer(100, 100);
 
   mockTime.nextFrame();
 
@@ -184,8 +184,8 @@ test("Pointer clicks and move", async () => {
     [
       "pointerPressed: false",
       "pointerJustPressed: false",
-      "pointerX: 300",
-      "pointerY: -300",
+      "pointerX: 0",
+      "pointerY: 0",
     ].join(),
     0,
     0
@@ -195,7 +195,8 @@ test("Pointer clicks and move", async () => {
 
   mockTime.nextFrame();
 
-  expect(textSpy).lastCalledWith(
+  // Moving outside of game size doesn't register
+  expect(textSpy).not.lastCalledWith(
     [
       "pointerPressed: false",
       "pointerJustPressed: false",

--- a/packages/replay-web/src/draw.ts
+++ b/packages/replay-web/src/draw.ts
@@ -1,36 +1,43 @@
 import { Texture, DeviceSize, TextureFont } from "@replay/core";
 
-/**
- * Revert the initial scale, for applying a new scale on different device
- * dimensions
- */
-export function revertCanvasScale(
-  ctx: CanvasRenderingContext2D,
-  { width, height, widthMargin, heightMargin }: DeviceSize,
-  scale: number
-) {
-  ctx.scale(1 / scale, 1 / scale);
-  ctx.translate(-(widthMargin + width / 2), -(heightMargin + height / 2));
-}
-
 export function drawCanvas(
   ctx: CanvasRenderingContext2D,
-  { width, height, deviceWidth, deviceHeight }: DeviceSize,
+  {
+    width,
+    height,
+    widthMargin,
+    heightMargin,
+    deviceWidth,
+    deviceHeight,
+  }: DeviceSize,
   imageElements: { [fileName: string]: HTMLImageElement },
   defaultFont: TextureFont
 ) {
+  ctx.save();
   const scale = Math.min(deviceWidth / width, deviceHeight / height);
+  const fullWidth = width + widthMargin * 2;
+  const fullHeight = height + heightMargin * 2;
   ctx.translate(deviceWidth / 2, deviceHeight / 2);
   ctx.scale(scale, scale);
   return {
     scale,
     render: (textures: Texture[]) => {
+      // First clear rect
       ctx.clearRect(
-        -deviceWidth / 2,
-        -deviceHeight / 2,
-        deviceWidth,
-        deviceHeight
+        -deviceWidth / 2 / scale,
+        -deviceHeight / 2 / scale,
+        deviceWidth / scale,
+        deviceHeight / scale
       );
+      // Set white background for game
+      ctx.fillStyle = "white";
+      ctx.fillRect(
+        -fullWidth / 2 / scale,
+        -fullHeight / 2 / scale,
+        fullWidth / scale,
+        fullHeight / scale
+      );
+
       textures.forEach((texture) => {
         const position = texture.props.position || { x: 0, y: 0 };
         const drawUtilsCtx = drawUtils(ctx, {

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -6,8 +6,8 @@ import {
 } from "@replay/core/dist/sprite";
 import {
   getInputs,
-  keyUpHandler,
-  keyDownHandler,
+  keyUpHandler as inputKeyUpHandler,
+  keyDownHandler as inputKeyDownHandler,
   resetInputs,
   Inputs,
   pointerUpHandler,
@@ -51,15 +51,31 @@ export function renderCanvas<S>(
    * Preferred method of placing the game in the browser window
    */
   dimensions: Dimensions = "game-coords",
-  canvas = document.body.appendChild(document.createElement("canvas"))
+  userCanvas?: HTMLCanvasElement
 ) {
+  const canvas = userCanvas || document.createElement("canvas");
+  if (!userCanvas) {
+    document.body.appendChild(canvas);
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const ctx = canvas.getContext("2d", { alpha: false })!;
+
+  let isInFocus = true;
+
+  const keyDownHandler = (e: KeyboardEvent) => {
+    if (!isInFocus) return;
+    inputKeyDownHandler(e);
+  };
+  const keyUpHandler = (e: KeyboardEvent) => {
+    if (!isInFocus) return;
+    inputKeyUpHandler(e);
+  };
 
   document.addEventListener("keydown", keyDownHandler, false);
   document.addEventListener("keyup", keyUpHandler, false);
 
-  window.addEventListener("resize", updateDeviceSize, false);
+  window.addEventListener("resize", updateDeviceSize as () => void, false);
 
   let prevDeviceSize: DeviceSize | undefined;
   let pointerDown: (e: PointerEvent) => void;
@@ -67,12 +83,15 @@ export function renderCanvas<S>(
   let pointerUp: (e: PointerEvent) => void;
   let scale: number;
 
-  function updateDeviceSize() {
+  function updateDeviceSize(cleanup?: boolean) {
     if (prevDeviceSize) {
       revertCanvasScale(ctx, prevDeviceSize, scale);
       document.removeEventListener("pointerdown", pointerDown);
       document.removeEventListener("pointermove", pointerMove);
       document.removeEventListener("pointerup", pointerUp);
+      if (cleanup) {
+        return;
+      }
     }
 
     const deviceSize = setDeviceSize(
@@ -109,14 +128,38 @@ export function renderCanvas<S>(
       scale,
     });
 
+    const isPointerOutsideGame = (x: number, y: number) =>
+      x > deviceSize.width / 2 + deviceSize.widthMargin ||
+      x < -deviceSize.width / 2 - deviceSize.widthMargin ||
+      y > deviceSize.height / 2 + deviceSize.heightMargin ||
+      y < -deviceSize.height / 2 + deviceSize.heightMargin;
+
     pointerDown = (e: PointerEvent) => {
-      pointerDownHandler(getX(e), getY(e));
+      const x = getX(e);
+      const y = getY(e);
+      if (isPointerOutsideGame(x, y)) {
+        isInFocus = false;
+        return;
+      }
+      isInFocus = true;
+
+      pointerDownHandler(x, y);
     };
     pointerMove = (e: PointerEvent) => {
-      pointerMoveHandler(getX(e), getY(e));
+      const x = getX(e);
+      const y = getY(e);
+      if (isPointerOutsideGame(x, y)) {
+        return;
+      }
+      pointerMoveHandler(x, y);
     };
     pointerUp = (e: PointerEvent) => {
-      pointerUpHandler(getX(e), getY(e));
+      const x = getX(e);
+      const y = getY(e);
+      if (isPointerOutsideGame(x, y)) {
+        return;
+      }
+      pointerUpHandler(x, y);
     };
     document.addEventListener("pointerdown", pointerDown, false);
     document.addEventListener("pointermove", pointerMove, false);
@@ -152,10 +195,11 @@ export function renderCanvas<S>(
   );
 
   let initTime: number | null = null;
+  let animationId = 0;
 
   function loop(textures: Texture[]) {
     render.ref?.(textures);
-    window.requestAnimationFrame((time) => {
+    animationId = window.requestAnimationFrame((time) => {
       if (initTime === null) {
         initTime = time - 1 / 60;
       }
@@ -218,7 +262,26 @@ export function renderCanvas<S>(
     loop(initTextures);
   });
 
-  return { loadPromise, audioElements }; // audioElements exported for testing
+  /**
+   * Unloads the game and removes all loops and event listeners
+   */
+  function cleanup() {
+    // hack to remove canvas content
+    canvas.width = canvas.width;
+
+    // Remove if we created canvas
+    if (!userCanvas) {
+      document.body.removeChild(canvas);
+    }
+
+    window.cancelAnimationFrame(animationId);
+    document.removeEventListener("keydown", inputKeyDownHandler, false);
+    document.removeEventListener("keyup", inputKeyUpHandler, false);
+    window.removeEventListener("resize", updateDeviceSize as () => void, false);
+    updateDeviceSize(true);
+  }
+
+  return { cleanup, loadPromise, audioElements }; // audioElements exported for testing
 }
 
 function deviceCreator(

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -16,7 +16,7 @@ import {
   clientXToGameX,
   clientYToGameY,
 } from "./input";
-import { drawCanvas, revertCanvasScale } from "./draw";
+import { drawCanvas } from "./draw";
 import { getDeviceSize, setDeviceSize, calculateDeviceSize } from "./size";
 import { Dimensions } from "./dimensions";
 
@@ -51,7 +51,11 @@ export function renderCanvas<S>(
    * Preferred method of placing the game in the browser window
    */
   dimensions: Dimensions = "game-coords",
-  userCanvas?: HTMLCanvasElement
+  userCanvas?: HTMLCanvasElement,
+  /**
+   * Override the view size, instead of using the window size
+   */
+  windowSize?: { width: number; height: number }
 ) {
   const canvas = userCanvas || document.createElement("canvas");
   if (!userCanvas) {
@@ -85,18 +89,18 @@ export function renderCanvas<S>(
 
   function updateDeviceSize(cleanup?: boolean) {
     if (prevDeviceSize) {
-      revertCanvasScale(ctx, prevDeviceSize, scale);
+      ctx.restore();
       document.removeEventListener("pointerdown", pointerDown);
       document.removeEventListener("pointermove", pointerMove);
       document.removeEventListener("pointerup", pointerUp);
-      if (cleanup) {
+      if (cleanup === true) {
         return;
       }
     }
 
     const deviceSize = setDeviceSize(
-      window.innerWidth,
-      window.innerHeight,
+      windowSize?.width || window.innerWidth,
+      windowSize?.height || window.innerHeight,
       dimensions,
       gameSprite.props.size
     );
@@ -175,8 +179,8 @@ export function renderCanvas<S>(
     getGetDevice: deviceCreator(
       audioElements,
       calculateDeviceSize(
-        window.innerWidth,
-        window.innerHeight,
+        windowSize?.width || window.innerWidth,
+        windowSize?.height || window.innerHeight,
         dimensions,
         gameSprite.props.size
       )

--- a/packages/replay-web/src/input.ts
+++ b/packages/replay-web/src/input.ts
@@ -57,7 +57,12 @@ export function getInputs(parentPosition: SpritePosition) {
 }
 
 export function keyDownHandler(e: KeyboardEvent) {
-  e.preventDefault();
+  if (
+    ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", " "].includes(e.key)
+  ) {
+    // avoid scrolling with space and arrow keys
+    e.preventDefault();
+  }
   inputs.keysDown[e.key] = true;
   inputs.keysJustPressed[e.key] = true;
 }

--- a/packages/replay-web/src/input.ts
+++ b/packages/replay-web/src/input.ts
@@ -57,6 +57,7 @@ export function getInputs(parentPosition: SpritePosition) {
 }
 
 export function keyDownHandler(e: KeyboardEvent) {
+  e.preventDefault();
   inputs.keysDown[e.key] = true;
   inputs.keysJustPressed[e.key] = true;
 }


### PR DESCRIPTION
- Game focus
  - Set game focus when clicked inside game
  - Only register key inputs when game is focussed
  - Don't scroll when focussed, fixes https://github.com/edbentley/replay/issues/1
- Return `cleanup` function in `renderCanvas`
- Fix black bars issue on small devices
- Allow override of viewport width and height in `renderCanvas`
