### PR TITLE
Testing for Sprites

### DIFF
--- a/dev-game/src/PlayStage.ts
+++ b/dev-game/src/PlayStage.ts
@@ -4,6 +4,7 @@ import { iOSInputs } from "../../packages/replay-swift";
 import { bulletX, bulletY } from "./utils";
 import { Score } from "./Score";
 import { WalkingGreenCapChar } from "./SpriteSheet";
+import { PosLogger } from "./PosLogger";
 
 interface State {
   playerRotation: number;
@@ -228,6 +229,7 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
         id: "highScore",
         position: { x: 100, y: 0 },
       }),
+      PosLogger({ id: "posLogger", position: { x: 100, y: 200 } }),
     ];
   },
 });

--- a/dev-game/src/PosLogger.ts
+++ b/dev-game/src/PosLogger.ts
@@ -1,0 +1,14 @@
+import { makeSprite } from "../../packages/replay-core/src";
+import { WebInputs } from "../../packages/replay-web/src";
+import { iOSInputs } from "../../packages/replay-swift";
+
+export const PosLogger = makeSprite<{}, undefined, WebInputs | iOSInputs>({
+  render({ device }) {
+    if (device.inputs.pointer.justPressed) {
+      device.log(
+        `x: ${device.inputs.pointer.x}, y: ${device.inputs.pointer.y}`
+      );
+    }
+    return [];
+  },
+});

--- a/dev-game/src/__tests__/game.test.ts
+++ b/dev-game/src/__tests__/game.test.ts
@@ -1,4 +1,7 @@
-import { WebInputs } from "../../../packages/replay-web/src";
+import {
+  WebInputs,
+  mapInputCoordinates,
+} from "../../../packages/replay-web/src";
 import { iOSInputs } from "../../../packages/replay-swift";
 import { testSprite } from "../../../packages/replay-test/src";
 import { Game, gameProps } from "..";
@@ -24,8 +27,10 @@ test("gameplay", () => {
     getByText,
     audio,
     store,
+    log,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs: inputs,
+    mapInputCoordinates,
     initRandom: [0.5],
     networkResponses: {
       get: {
@@ -126,4 +131,7 @@ test("gameplay", () => {
   jumpToFrame(() => getByText("Game Over")[0]);
 
   expect(store).toEqual({ highScore: "1" });
+
+  // check mapper function works
+  expect(log).toBeCalledWith("x: -100, y: -200");
 });

--- a/dev-game/src/__tests__/game.test.ts
+++ b/dev-game/src/__tests__/game.test.ts
@@ -1,6 +1,6 @@
 import { WebInputs } from "../../../packages/replay-web/src";
 import { iOSInputs } from "../../../packages/replay-swift";
-import { testGame } from "../../../packages/replay-test/src";
+import { testSprite } from "../../../packages/replay-test/src";
 import { Game, gameProps } from "..";
 
 test("gameplay", () => {
@@ -24,7 +24,7 @@ test("gameplay", () => {
     getByText,
     audio,
     store,
-  } = testGame(Game(gameProps), {
+  } = testSprite(Game(gameProps), gameProps, {
     initInputs: inputs,
     initRandom: [0.5],
     networkResponses: {

--- a/packages/replay-starter-js/src/__tests__/game.test.js
+++ b/packages/replay-starter-js/src/__tests__/game.test.js
@@ -1,4 +1,4 @@
-import { testGame } from "@replay/test";
+import { testSprite } from "@replay/test";
 import { Game, gameProps } from "..";
 
 test("gameplay", () => {
@@ -18,7 +18,7 @@ test("gameplay", () => {
     updateInputs,
     getTexture,
     audio,
-  } = testGame(Game(gameProps), { initInputs });
+  } = testSprite(Game(gameProps), gameProps, { initInputs });
 
   expect(getTexture("icon").props.position).toEqual({
     x: 0,

--- a/packages/replay-starter-js/src/__tests__/game.test.js
+++ b/packages/replay-starter-js/src/__tests__/game.test.js
@@ -1,4 +1,5 @@
 import { testSprite } from "@replay/test";
+import { mapInputCoordinates } from "@replay/web";
 import { Game, gameProps } from "..";
 
 test("gameplay", () => {
@@ -18,7 +19,10 @@ test("gameplay", () => {
     updateInputs,
     getTexture,
     audio,
-  } = testSprite(Game(gameProps), gameProps, { initInputs });
+  } = testSprite(Game(gameProps), gameProps, {
+    initInputs,
+    mapInputCoordinates,
+  });
 
   expect(getTexture("icon").props.position).toEqual({
     x: 0,

--- a/packages/replay-starter-ts/src/__tests__/game.test.ts
+++ b/packages/replay-starter-ts/src/__tests__/game.test.ts
@@ -1,5 +1,5 @@
 import { testSprite } from "@replay/test";
-import { WebInputs } from "@replay/web";
+import { WebInputs, mapInputCoordinates } from "@replay/web";
 import { iOSInputs } from "@replay/swift";
 import { Game, gameProps } from "..";
 
@@ -20,7 +20,10 @@ test("gameplay", () => {
     updateInputs,
     getTexture,
     audio,
-  } = testSprite(Game(gameProps), gameProps, { initInputs });
+  } = testSprite(Game(gameProps), gameProps, {
+    initInputs,
+    mapInputCoordinates,
+  });
 
   expect(getTexture("icon").props.position).toEqual({
     x: 0,

--- a/packages/replay-starter-ts/src/__tests__/game.test.ts
+++ b/packages/replay-starter-ts/src/__tests__/game.test.ts
@@ -1,4 +1,4 @@
-import { testGame } from "@replay/test";
+import { testSprite } from "@replay/test";
 import { WebInputs } from "@replay/web";
 import { iOSInputs } from "@replay/swift";
 import { Game, gameProps } from "..";
@@ -20,7 +20,7 @@ test("gameplay", () => {
     updateInputs,
     getTexture,
     audio,
-  } = testGame(Game(gameProps), { initInputs });
+  } = testSprite(Game(gameProps), gameProps, { initInputs });
 
   expect(getTexture("icon").props.position).toEqual({
     x: 0,

--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -314,6 +314,24 @@ test("can test individual Sprites", () => {
   expect(getByText("Hello")).toBeTruthy();
 });
 
+test("can map input coordinates to relative coordinates within Sprite", () => {
+  const { log } = testSprite(Game(gameProps), gameProps, {
+    initInputs: {
+      x: 20,
+    },
+    mapInputCoordinates(parentPos, inputs) {
+      if (!parentPos || !inputs.x) return inputs;
+      return {
+        ...inputs,
+        x: inputs.x - parentPos.x,
+      };
+    },
+  });
+
+  // x is -100 from input due to mapping function
+  expect(log).toBeCalledWith("x in Text Sprite is -80");
+});
+
 // --- Mock Game
 
 interface State {
@@ -321,6 +339,7 @@ interface State {
   showEnemy: boolean;
 }
 interface Inputs {
+  x?: number;
   pressed?: boolean;
   testInput?: string;
 }
@@ -452,8 +471,11 @@ const Game = makeSprite<GameProps, State, Inputs>({
   },
 });
 
-const Text = makeSprite<{ text: string }>({
-  render({ props }) {
+const Text = makeSprite<{ text: string }, undefined, Inputs>({
+  render({ props, device }) {
+    if (device.inputs.x) {
+      device.log(`x in Text Sprite is ${device.inputs.x}`);
+    }
     return [
       t.text({
         text: props.text,

--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -1,8 +1,8 @@
 import { makeSprite, t, GameProps } from "@replay/core";
-import { testGame } from "../index";
+import { testSprite } from "../index";
 
 test("getTextures, nextFrame", () => {
-  const { getTextures, nextFrame } = testGame(Game(gameProps), {
+  const { getTextures, nextFrame } = testSprite(Game(gameProps), gameProps, {
     initInputs: {
       pressed: true,
     },
@@ -80,7 +80,7 @@ test("getTextures, nextFrame", () => {
 });
 
 test("jumpToFrame, getTexture", () => {
-  const { jumpToFrame, getTexture } = testGame(Game(gameProps), {
+  const { jumpToFrame, getTexture } = testSprite(Game(gameProps), gameProps, {
     initInputs: {
       pressed: true,
     },
@@ -92,11 +92,15 @@ test("jumpToFrame, getTexture", () => {
 });
 
 test("setRandomNumbers, log", () => {
-  const { setRandomNumbers, log, nextFrame } = testGame(Game(gameProps), {
-    initInputs: {
-      testInput: "logRandom",
-    },
-  });
+  const { setRandomNumbers, log, nextFrame } = testSprite(
+    Game(gameProps),
+    gameProps,
+    {
+      initInputs: {
+        testInput: "logRandom",
+      },
+    }
+  );
   expect(log).not.toBeCalled();
 
   nextFrame();
@@ -120,7 +124,7 @@ test("setRandomNumbers, log", () => {
 });
 
 test("initRandom", () => {
-  const { log, nextFrame } = testGame(Game(gameProps), {
+  const { log, nextFrame } = testSprite(Game(gameProps), gameProps, {
     initInputs: {
       testInput: "logRandom",
     },
@@ -138,7 +142,10 @@ test("initRandom", () => {
 });
 
 test("textureExists, updateInputs", () => {
-  const { textureExists, updateInputs, nextFrame } = testGame(Game(gameProps));
+  const { textureExists, updateInputs, nextFrame } = testSprite(
+    Game(gameProps),
+    gameProps
+  );
   expect(textureExists("player")).toBe(true);
   expect(textureExists("enemy")).toBe(false);
 
@@ -149,7 +156,7 @@ test("textureExists, updateInputs", () => {
 });
 
 test("getByText", () => {
-  const { getByText, nextFrame } = testGame(Game(gameProps), {
+  const { getByText, nextFrame } = testSprite(Game(gameProps), gameProps, {
     initInputs: {
       pressed: true,
     },
@@ -165,7 +172,7 @@ test("getByText", () => {
 });
 
 test("now", () => {
-  const { log, nextFrame } = testGame(Game(gameProps), {
+  const { log, nextFrame } = testSprite(Game(gameProps), gameProps, {
     initInputs: {
       testInput: "logNow",
     },
@@ -177,7 +184,7 @@ test("now", () => {
 });
 
 test("timeout", () => {
-  const { jumpToFrame, getTexture } = testGame(Game(gameProps), {
+  const { jumpToFrame, getTexture } = testSprite(Game(gameProps), gameProps, {
     initInputs: {
       testInput: "timeout",
     },
@@ -187,11 +194,15 @@ test("timeout", () => {
 });
 
 test("audio", () => {
-  const { nextFrame, audio, log, updateInputs } = testGame(Game(gameProps), {
-    initInputs: {
-      testInput: "audioPlay",
-    },
-  });
+  const { nextFrame, audio, log, updateInputs } = testSprite(
+    Game(gameProps),
+    gameProps,
+    {
+      initInputs: {
+        testInput: "audioPlay",
+      },
+    }
+  );
 
   nextFrame();
   expect(audio.play).toBeCalledWith("sound.wav");
@@ -223,25 +234,29 @@ test("audio", () => {
 });
 
 test("network", () => {
-  const { nextFrame, network, log, updateInputs } = testGame(Game(gameProps), {
-    initInputs: {
-      testInput: "networkGET",
-    },
-    networkResponses: {
-      get: {
-        "/test-get": () => ({ got: "a get" }),
+  const { nextFrame, network, log, updateInputs } = testSprite(
+    Game(gameProps),
+    gameProps,
+    {
+      initInputs: {
+        testInput: "networkGET",
       },
-      put: {
-        "/test-put": (body: any) => ({ got: body.hi }),
+      networkResponses: {
+        get: {
+          "/test-get": () => ({ got: "a get" }),
+        },
+        put: {
+          "/test-put": (body: any) => ({ got: body.hi }),
+        },
+        post: {
+          "/test-post": (body: any) => ({ got: body.hi }),
+        },
+        delete: {
+          "/test-delete": () => ({ got: "a delete" }),
+        },
       },
-      post: {
-        "/test-post": (body: any) => ({ got: body.hi }),
-      },
-      delete: {
-        "/test-delete": () => ({ got: "a delete" }),
-      },
-    },
-  });
+    }
+  );
 
   nextFrame();
   expect(network.get).toBeCalled();
@@ -269,9 +284,13 @@ test("network", () => {
 });
 
 test("storage", () => {
-  const { nextFrame, store, updateInputs } = testGame(Game(gameProps), {
-    initStore: { origStore: "origValue" },
-  });
+  const { nextFrame, store, updateInputs } = testSprite(
+    Game(gameProps),
+    gameProps,
+    {
+      initStore: { origStore: "origValue" },
+    }
+  );
 
   nextFrame();
   expect(store).toEqual({ origStore: "origValue" });
@@ -283,6 +302,16 @@ test("storage", () => {
   updateInputs({ testInput: "storage-remove" });
   nextFrame();
   expect(store).toEqual({ origStore: "origValue" });
+});
+
+test("can test individual Sprites", () => {
+  const { getByText, getTextures } = testSprite(
+    Text({ id: "Text", text: "Hello" }),
+    gameProps
+  );
+
+  expect(getTextures().length).toBe(1);
+  expect(getByText("Hello")).toBeTruthy();
 });
 
 // --- Mock Game
@@ -398,15 +427,14 @@ const Game = makeSprite<GameProps, State, Inputs>({
         radius: 10,
         color: "blue",
       }),
-      t.text({
+      Text({
+        id: "Text",
         position: {
           x: 100,
           y: 0,
           rotation: 0,
         },
         text: `x: ${state.x}`,
-        color: "red",
-        font: { name: "Arial", size: 12 },
       }),
       state.showEnemy
         ? t.circle({
@@ -420,6 +448,18 @@ const Game = makeSprite<GameProps, State, Inputs>({
             color: "red",
           })
         : null,
+    ];
+  },
+});
+
+const Text = makeSprite<{ text: string }>({
+  render({ props }) {
+    return [
+      t.text({
+        text: props.text,
+        color: "red",
+        font: { name: "Arial", size: 12 },
+      }),
     ];
   },
 });

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -23,7 +23,7 @@ import { Dimensions } from "./dimensions";
 
 type SpritePosition = SpritePositionObj["position"];
 
-export { Inputs as WebInputs } from "./input";
+export { Inputs as WebInputs, mapInputCoordinates } from "./input";
 export { Dimensions } from "./dimensions";
 
 const DEFAULT_FONT = {

--- a/packages/replay-web/src/input.ts
+++ b/packages/replay-web/src/input.ts
@@ -24,7 +24,7 @@ export interface Inputs {
   };
 }
 
-let inputs: Inputs = {
+let mutableInputs: Inputs = {
   keysDown: {},
   keysJustPressed: {},
   pointer: {
@@ -36,7 +36,13 @@ let inputs: Inputs = {
   },
 };
 
-export function getInputs(parentPosition: SpritePosition) {
+/**
+ * This can be used with @replay/test to map pointer (x, y) coordinates to its
+ * relative coordinate within each Sprite
+ */
+export function mapInputCoordinates<
+  I extends { pointer: { x: number; y: number } }
+>(parentPosition: SpritePosition, inputs: I) {
   if (!parentPosition) return inputs;
 
   // Need to convert point from absolute coordinates to sprite coordinates.
@@ -56,6 +62,10 @@ export function getInputs(parentPosition: SpritePosition) {
   };
 }
 
+export function getInputs(parentPosition: SpritePosition) {
+  return mapInputCoordinates(parentPosition, mutableInputs);
+}
+
 export function keyDownHandler(e: KeyboardEvent) {
   if (
     ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", " "].includes(e.key)
@@ -63,12 +73,12 @@ export function keyDownHandler(e: KeyboardEvent) {
     // avoid scrolling with space and arrow keys
     e.preventDefault();
   }
-  inputs.keysDown[e.key] = true;
-  inputs.keysJustPressed[e.key] = true;
+  mutableInputs.keysDown[e.key] = true;
+  mutableInputs.keysJustPressed[e.key] = true;
 }
 
 export function keyUpHandler(e: KeyboardEvent) {
-  delete inputs.keysDown[e.key];
+  delete mutableInputs.keysDown[e.key];
 }
 
 /**
@@ -104,7 +114,7 @@ export const clientYToGameY = ({
   -(e.clientY - canvasOffsetTop) / scale + heightMargin + height / 2;
 
 export function pointerDownHandler(x: number, y: number) {
-  inputs.pointer = {
+  mutableInputs.pointer = {
     pressed: true,
     justPressed: true,
     justReleased: false,
@@ -114,29 +124,29 @@ export function pointerDownHandler(x: number, y: number) {
 }
 
 export function pointerMoveHandler(x: number, y: number) {
-  inputs.pointer.x = x;
-  inputs.pointer.y = y;
+  mutableInputs.pointer.x = x;
+  mutableInputs.pointer.y = y;
 }
 
 export function pointerUpHandler(x: number, y: number) {
-  inputs.pointer.justPressed = false;
-  inputs.pointer.pressed = false;
-  inputs.pointer.justReleased = true;
-  inputs.pointer.x = x;
-  inputs.pointer.y = y;
+  mutableInputs.pointer.justPressed = false;
+  mutableInputs.pointer.pressed = false;
+  mutableInputs.pointer.justReleased = true;
+  mutableInputs.pointer.x = x;
+  mutableInputs.pointer.y = y;
 }
 
 export function pointerOutHandler() {
-  inputs.pointer.justPressed = false;
-  inputs.pointer.pressed = false;
+  mutableInputs.pointer.justPressed = false;
+  mutableInputs.pointer.pressed = false;
 }
 
 export function resetInputs() {
-  inputs = {
-    keysDown: inputs.keysDown,
+  mutableInputs = {
+    keysDown: mutableInputs.keysDown,
     keysJustPressed: {},
     pointer: {
-      ...inputs.pointer,
+      ...mutableInputs.pointer,
       justPressed: false,
       justReleased: false,
     },

--- a/website/docs/device.md
+++ b/website/docs/device.md
@@ -38,7 +38,7 @@ const hitX = inputs.pointer.x;
 ```
 
 :::tip Important
-The pointer is relative to the Sprite's position and rotation. If your Sprite has an `x` position of `100`, and you click at an `x` position of `50`, the value of `inputs.pointer.x` in the Sprite will be translated to `-50`. However this translation is _not_ done in [Replay Test](test.md).
+The pointer is relative to the Sprite's position and rotation. If your Sprite has an `x` position of `100`, and you click at an `x` position of `50`, the value of `inputs.pointer.x` in the Sprite will be translated to `-50`. To do this translation in [Replay Test](test.md) you can pass in a `mapInputCoordinates` function.
 :::
 
 ### `size`

--- a/website/docs/test.md
+++ b/website/docs/test.md
@@ -18,6 +18,7 @@ The `@replay/test` package is useful for writing tests in Jest for your Replay g
 - `gameProps`: The props defined for your top-level `Game`. This sets the device size during tests.
 - `options`: (Optional) An object with the following properties:
   - `initInputs`: (Optional) The inputs your `device` returns. Match with the platforms you're targeting.
+  - `mapInputCoordinates`: (Optional) A mapping function to adjust an input's (x, y) coordinate to its relative value within a Sprite. The [Web package](web.md) exports this for pointer values.
   - `initRandom`: (Optional) An array of numbers that `random()` will call, starting from index 0 and looping if it reaches the end. Allows for predictable randomness.
   - `size`: (Optional) Set the size parameter passed into Sprites.
   - `initStore`: (Optional) Set the init store for local storage.
@@ -69,7 +70,8 @@ updateInputs({
     justPressed: true,
     justReleased: false,
     // Here the pointer position will have the
-    // same coordinates in all sprites
+    // same coordinates in all Sprites unless
+    // you set mapInputCoordinates
     x: 0,
     y: 0,
   },
@@ -169,6 +171,7 @@ test("Can shoot bullet", () => {
 
   const { nextFrame, updateInputs, getTexture, textureExists } = testSprite(
     Game(gameProps),
+    gameProps,
     {
       initInputs,
     }

--- a/website/docs/test.md
+++ b/website/docs/test.md
@@ -10,11 +10,12 @@ Once you've worked on your game for a while, it's a good idea to add some tests 
 
 The `@replay/test` package is useful for writing tests in Jest for your Replay game. It provides a test platform, which works the same as any other like web and iOS, but returns helpful utility functions for testing.
 
-## `testGame(game, options)`
+## `testSprite(sprite, gameProps, options)`
 
 #### Parameters
 
-- `game`: Your top-level `Game` Sprite called with its props, e.g. `Game(gameProps)`.
+- `sprite`: The Sprite you want to test called with its props, e.g. `Player(playerProps)`.
+- `gameProps`: The props defined for your top-level `Game`. This sets the device size during tests.
 - `options`: (Optional) An object with the following properties:
   - `initInputs`: (Optional) The inputs your `device` returns. Match with the platforms you're targeting.
   - `initRandom`: (Optional) An array of numbers that `random()` will call, starting from index 0 and looping if it reaches the end. Allows for predictable randomness.
@@ -31,7 +32,7 @@ The `@replay/test` package is useful for writing tests in Jest for your Replay g
   },
   ```
 
-`testGame` returns an object with the following fields:
+`testSprite` returns an object with the following fields:
 
 ### `nextFrame()`
 
@@ -152,7 +153,7 @@ expect(store).toEqual({ highScore: 5 });
 <TabItem value="js">
 
 ```js
-import { testGame } from "@replay/test";
+import { testSprite } from "@replay/test";
 import { Game, gameProps } from "..";
 
 test("Can shoot bullet", () => {
@@ -166,7 +167,7 @@ test("Can shoot bullet", () => {
     },
   };
 
-  const { nextFrame, updateInputs, getTexture, textureExists } = testGame(
+  const { nextFrame, updateInputs, getTexture, textureExists } = testSprite(
     Game(gameProps),
     {
       initInputs,
@@ -198,7 +199,7 @@ test("Can shoot bullet", () => {
 <TabItem value="ts">
 
 ```ts
-import { testGame } from "@replay/test";
+import { testSprite } from "@replay/test";
 import { WebInputs } from "@replay/web";
 import { iOSInputs } from "@replay/swift";
 import { Game, gameProps } from "..";
@@ -214,7 +215,7 @@ test("Can shoot bullet", () => {
     },
   };
 
-  const { nextFrame, updateInputs, getTexture, textureExists } = testGame(
+  const { nextFrame, updateInputs, getTexture, textureExists } = testSprite(
     Game(gameProps),
     {
       initInputs,

--- a/website/docs/tutorial/20.md
+++ b/website/docs/tutorial/20.md
@@ -4,7 +4,7 @@ The `@replay/test` package provides a platform to automate gameplay tests for ou
 
 Using [Jest](https://jestjs.io/) we can write an initial test to confirm we can start the game.
 
-In `__tests__/game.test` replace what's there with the code on the right. We pass our `Game` Sprite (and `gameProps`) into the `testGame` function, which returns some more useful functions for inspecting our game. Since the test platform doesn't know if we want to run on web or iOS, we need to supply the inputs we'd expect on those platforms through `initInputs`.
+In `__tests__/game.test` replace what's there with the code on the right. We pass our `Game` Sprite (and `gameProps`) into the `testSprite` function, which returns some more useful functions for inspecting our game. Since the test platform doesn't know if we want to run on web or iOS, we need to supply the inputs we'd expect on those platforms through `initInputs`.
 
 Below that `getByText(mainMenuText)` searches all `t.text` Textures that match the string passed in, or throws an error if it can't find it. This confirms that our main menu is visible on the initial render.
 

--- a/website/docs/tutorial/21.md
+++ b/website/docs/tutorial/21.md
@@ -2,7 +2,7 @@
 
 Let's expand our test to play the game. We're going to check the bird can fly past 2 pipes, then crash into one, ending up with a score of `2`.
 
-We pass an `initRandom` field into `testGame`. This ensures `device.random()` calls always produce the same result, in this case `0.5`, then `0.5`, then `0`. With this we can ensure our bird knows what height to fly at.
+We pass an `initRandom` field into `testSprite`. This ensures `device.random()` calls always produce the same result, in this case `0.5`, then `0.5`, then `0`. With this we can ensure our bird knows what height to fly at.
 
 We create a function `keepBirdInMiddle` which is going to keep clicking the screen when the bird's `y` position is too low, to keep the bird jumping at the right height.
 

--- a/website/docs/web.md
+++ b/website/docs/web.md
@@ -40,6 +40,10 @@ renderCanvas(
 );
 ```
 
+### `mapInputCoordinates(parentPosition, inputs)`
+
+This can be used by [Replay Test](test.md), see the docs there for more info.
+
 ## Inputs
 
 The `device.inputs` parameter of Sprite methods is of type:

--- a/website/src/pages/tutorial/21.js
+++ b/website/src/pages/tutorial/21.js
@@ -21,7 +21,7 @@ function Tutorial() {
         {
           file: "__tests__/game.test.ts",
           code: testTs,
-          highlight: [5, 6, 8, "24-26", 29, 30, "53-85"],
+          highlight: [5, 6, 8, "24-26", 29, 30, "52-84"],
         },
         {
           file: "bird.ts",
@@ -33,7 +33,7 @@ function Tutorial() {
         {
           file: "__tests__/game.test.js",
           code: testJs,
-          highlight: [3, 4, 6, "22-24", 27, 28, "51-83"],
+          highlight: [3, 4, 6, "22-24", 27, 28, "50-82"],
         },
         {
           file: "bird.js",

--- a/website/src/tutorial/20/js/__tests__/game.test.js
+++ b/website/src/tutorial/20/js/__tests__/game.test.js
@@ -28,7 +28,6 @@ test("Can start game", () => {
       pressed: false,
       justPressed: false,
       justReleased: true,
-      // Note that the pointer position has the same coordinates in all Sprites
       x: 0,
       y: 0,
     },

--- a/website/src/tutorial/20/js/__tests__/game.test.js
+++ b/website/src/tutorial/20/js/__tests__/game.test.js
@@ -1,4 +1,4 @@
-import { testGame } from "@replay/test";
+import { testSprite } from "@replay/test";
 import { Game, gameProps } from "..";
 
 test("Can start game", () => {
@@ -13,9 +13,13 @@ test("Can start game", () => {
   };
   const mainMenuText = "Start";
 
-  const { nextFrame, updateInputs, getByText } = testGame(Game(gameProps), {
-    initInputs,
-  });
+  const { nextFrame, updateInputs, getByText } = testSprite(
+    Game(gameProps),
+    gameProps,
+    {
+      initInputs,
+    }
+  );
 
   expect(getByText(mainMenuText)).toBeDefined();
 

--- a/website/src/tutorial/20/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/20/ts/__tests__/game.test.ts
@@ -30,7 +30,6 @@ test("Can start game", () => {
       pressed: false,
       justPressed: false,
       justReleased: true,
-      // Note that the pointer position has the same coordinates in all Sprites
       x: 0,
       y: 0,
     },

--- a/website/src/tutorial/20/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/20/ts/__tests__/game.test.ts
@@ -1,4 +1,4 @@
-import { testGame } from "@replay/test";
+import { testSprite } from "@replay/test";
 import { WebInputs } from "@replay/web";
 import { iOSInputs } from "@replay/swift";
 import { Game, gameProps } from "..";
@@ -15,9 +15,13 @@ test("Can start game", () => {
   };
   const mainMenuText = "Start";
 
-  const { nextFrame, updateInputs, getByText } = testGame(Game(gameProps), {
-    initInputs,
-  });
+  const { nextFrame, updateInputs, getByText } = testSprite(
+    Game(gameProps),
+    gameProps,
+    {
+      initInputs,
+    }
+  );
 
   expect(getByText(mainMenuText)).toBeDefined();
 

--- a/website/src/tutorial/21/js/__tests__/game.test.js
+++ b/website/src/tutorial/21/js/__tests__/game.test.js
@@ -35,7 +35,6 @@ test("Can reach a score of 2", () => {
       pressed: false,
       justPressed: false,
       justReleased: true,
-      // Note that the pointer position has the same coordinates in all Sprites
       x: 0,
       y: 0,
     },

--- a/website/src/tutorial/21/js/__tests__/game.test.js
+++ b/website/src/tutorial/21/js/__tests__/game.test.js
@@ -1,4 +1,4 @@
-import { testGame } from "@replay/test";
+import { testSprite } from "@replay/test";
 import { Game, gameProps } from "..";
 import { pipeGap } from "../pipe";
 import { birdHeight } from "../bird";
@@ -22,7 +22,7 @@ test("Can reach a score of 2", () => {
     getTexture,
     jumpToFrame,
     audio,
-  } = testGame(Game(gameProps), {
+  } = testSprite(Game(gameProps), gameProps, {
     initInputs,
     // First two pipes will have gap in middle, third pipe lower down
     initRandom: [0.5, 0.5, 0],

--- a/website/src/tutorial/21/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/21/ts/__tests__/game.test.ts
@@ -37,7 +37,6 @@ test("Can reach a score of 2", () => {
       pressed: false,
       justPressed: false,
       justReleased: true,
-      // Note that the pointer position has the same coordinates in all Sprites
       x: 0,
       y: 0,
     },

--- a/website/src/tutorial/21/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/21/ts/__tests__/game.test.ts
@@ -1,4 +1,4 @@
-import { testGame } from "@replay/test";
+import { testSprite } from "@replay/test";
 import { WebInputs } from "@replay/web";
 import { iOSInputs } from "@replay/swift";
 import { Game, gameProps } from "..";
@@ -24,7 +24,7 @@ test("Can reach a score of 2", () => {
     getTexture,
     jumpToFrame,
     audio,
-  } = testGame(Game(gameProps), {
+  } = testSprite(Game(gameProps), gameProps, {
     initInputs,
     // First two pipes will have gap in middle, third pipe lower down
     initRandom: [0.5, 0.5, 0],


### PR DESCRIPTION
- (Breaking change) Renames `testGame` to `testSprite` and passes in `gameProps` separately
- Allow adjusting pointer (x, y) coordinates in tests