### PR TITLE
throw correct error inside jumpToFrame

### DIFF
--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -366,7 +366,7 @@ test("jumpToFrame throws last error", () => {
   });
 
   expect(() => jumpToFrame(() => getTexture("i-dont-exist"))).toThrowError(
-    `No textures found with test id "i-dont-exist"`
+    `Timeout of 1000 gameplay seconds reached on jumpToFrame with error:\n\nNo textures found with test id "i-dont-exist"`
   );
 });
 

--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -360,6 +360,16 @@ test("can get global position and rotation of deeply nested textures", () => {
   expect(textures[0].props.rotation).toBe(0);
 });
 
+test("jumpToFrame throws last error", () => {
+  const { jumpToFrame, getTexture } = testSprite(Game(gameProps), gameProps, {
+    initInputs: {},
+  });
+
+  expect(() => jumpToFrame(() => getTexture("i-dont-exist"))).toThrowError(
+    `No textures found with test id "i-dont-exist"`
+  );
+});
+
 // --- Mock Game
 
 interface State {

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -330,6 +330,8 @@ export function testSprite<P, S, I>(
    * pass and condition not met / still errors.
    */
   function jumpToFrame(condition: () => boolean | Texture) {
+    let lastError: Error | null = null;
+
     for (let i = 0; i < 60000; i++) {
       nextFrame();
       try {
@@ -337,9 +339,15 @@ export function testSprite<P, S, I>(
           return;
         }
       } catch (e) {
+        lastError = e;
         // continue trying
       }
     }
+
+    if (lastError) {
+      throw lastError;
+    }
+
     throw Error("Timeout of 1000 gameplay seconds reached on jumpToFrame");
   }
 

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -330,7 +330,7 @@ export function testSprite<P, S, I>(
    * pass and condition not met / still errors.
    */
   function jumpToFrame(condition: () => boolean | Texture) {
-    let lastError: Error | null = null;
+    let lastErrorMsg: string | null = null;
 
     for (let i = 0; i < 60000; i++) {
       nextFrame();
@@ -339,16 +339,18 @@ export function testSprite<P, S, I>(
           return;
         }
       } catch (e) {
-        lastError = e;
+        lastErrorMsg = (e as Error)?.message;
         // continue trying
       }
     }
 
-    if (lastError) {
-      throw lastError;
+    if (lastErrorMsg) {
+      throw Error(
+        `Timeout of 1000 gameplay seconds reached on jumpToFrame with error:\n\n${lastErrorMsg}`
+      );
+    } else {
+      throw Error("Timeout of 1000 gameplay seconds reached on jumpToFrame");
     }
-
-    throw Error("Timeout of 1000 gameplay seconds reached on jumpToFrame");
   }
 
   function getTextures() {


### PR DESCRIPTION
Fixes error suppression inside jumpToFrame when there is one. Instead of always throwing the `Timeout of 1000 gameplay seconds reached on jumpToFrame` error, it will throw the last caught error if there is one.