### PR TITLE
Expanded audio API

### DIFF
--- a/packages/replay-core/src/device.ts
+++ b/packages/replay-core/src/device.ts
@@ -56,6 +56,10 @@ export interface Device<I> {
     getPosition: () => number;
     play: (fromPosition?: number, loop?: boolean) => void;
     pause: () => void;
+    getStatus: () => string;
+    getVolume: () => number;
+    setVolume: (volume: number) => void;
+    getDuration: () => number;
   };
 
   /**

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -375,6 +375,25 @@ function deviceCreator(
         pause: () => {
           getAudioElement(false).pause();
         },
+        getVolume: () => {
+          return getAudioElement(false).volume;
+        },
+        setVolume: (volume) => {
+          getAudioElement(false).volume = volume;
+        },
+        getDuration: () => {
+          return getAudioElement(false).duration;
+        },
+        getStatus: () => {
+          const { paused, ended } = getAudioElement(false);
+          let status = "paused";
+          if (paused === false) {
+            status = "playing";
+          } else if (ended === true) {
+            status = "ended";
+          }
+          return status;
+        },
       };
     },
     network: {

--- a/website/docs/device.md
+++ b/website/docs/device.md
@@ -143,6 +143,35 @@ Get the current play position of the sound in seconds.
 mySound.getPosition();
 ```
 
+#### `getStatus`
+
+Get the current status of the sound. There are three possibilities:
+
+* `playing`: sound currently playing
+* `paused`: sound is at position 0 and not playing
+* `ended`: sound has reached its end and is no longer playing
+
+```js
+mySound.getStatus();
+```
+
+#### `getVolume` / `setVolume`
+
+Get or set the volume for the sound. A volume of 0 is muted, a volume of 1 is maximum.
+
+```js
+mySound.getVolume();
+mySound.setVolume(0.25);
+```
+
+#### `getDuration`
+
+Get the duration of the sound in seconds.
+
+```js
+mySound.getDuration();
+```
+
 ### `network`
 
 Make platform-independent networks calls. Returns and sends data as a JSON object.


### PR DESCRIPTION
This implements #36 for replay-core and replay-web. I'll need some help with the Swift version though.