### PR TITLE
Test blocking and errors

### DIFF
--- a/dev-game/jest.config.js
+++ b/dev-game/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   testEnvironment: "node",
   testMatch: ["**/__tests__/**/*.test.ts"],
   globals: { ASSET_NAMES: {} },
+  testTimeout: 30000,
 };

--- a/dev-game/src/__tests__/game.test.ts
+++ b/dev-game/src/__tests__/game.test.ts
@@ -6,7 +6,7 @@ import { iOSInputs } from "../../../packages/replay-swift/src";
 import { testSprite } from "../../../packages/replay-test/src";
 import { Game, gameProps } from "..";
 
-test("gameplay", () => {
+test("gameplay", async () => {
   const inputs: WebInputs | iOSInputs = {
     pointer: {
       pressed: false,
@@ -49,7 +49,7 @@ test("gameplay", () => {
 
   getByText("Loading");
 
-  jumpToFrame(() => textureExists("player"));
+  await jumpToFrame(() => textureExists("player"));
   expect(getTexture("player").props.x).toBe(0);
   expect(getTexture("player").props.y).toBe(-150);
 
@@ -62,7 +62,7 @@ test("gameplay", () => {
 
   // enemy spawns in middle
 
-  jumpToFrame(() => textureExists("enemy1"));
+  await jumpToFrame(() => textureExists("enemy1"));
   expect(getTexture("enemy1").props.x).toBe(0);
   expect(getTexture("enemy1").props.y).toBe(158);
   expect(getTexture("enemy1").props.rotation).toBe(0);
@@ -106,7 +106,7 @@ test("gameplay", () => {
 
   // enemy gets hit!
 
-  jumpToFrame(() => !textureExists("enemy1"));
+  await jumpToFrame(() => !textureExists("enemy1"));
 
   expect(getTexture("bullet1").props.x).toBe(0);
   expect(getTexture("bullet1").props.y).toBe(100);
@@ -115,7 +115,7 @@ test("gameplay", () => {
 
   // enemy spawns to left
 
-  jumpToFrame(() => textureExists("enemy1"));
+  await jumpToFrame(() => textureExists("enemy1"));
   expect(getTexture("enemy1").props.x).toBe(-150);
 
   // fire in the middle again
@@ -151,7 +151,7 @@ test("gameplay", () => {
 
   // bullet misses enemy and game over!
 
-  jumpToFrame(() => getByText("Game Over")[0]);
+  await jumpToFrame(() => getByText("Game Over")[0]);
 
   expect(store).toEqual({ highScore: "1" });
 

--- a/dev-game/src/__tests__/game.test.ts
+++ b/dev-game/src/__tests__/game.test.ts
@@ -47,7 +47,7 @@ test("gameplay", async () => {
     nativeSpriteNames: ["TextInput"],
   });
 
-  getByText("Loading");
+  expect(getByText("Loading").length).toBe(1);
 
   await jumpToFrame(() => textureExists("player"));
   expect(getTexture("player").props.x).toBe(0);
@@ -151,7 +151,7 @@ test("gameplay", async () => {
 
   // bullet misses enemy and game over!
 
-  await jumpToFrame(() => getByText("Game Over")[0]);
+  await jumpToFrame(() => getByText("Game Over").length > 0);
 
   expect(store).toEqual({ highScore: "1" });
 

--- a/packages/replay-starter-js/jest.config.js
+++ b/packages/replay-starter-js/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   transformIgnorePatterns: ["/node_modules/(?!@replay/).+\\.js$"],
   globals: { ASSET_NAMES: {} },
+  testTimeout: 30000,
 };

--- a/packages/replay-starter-js/src/__tests__/game.test.js
+++ b/packages/replay-starter-js/src/__tests__/game.test.js
@@ -2,7 +2,7 @@ import { testSprite } from "@replay/test";
 import { mapInputCoordinates } from "@replay/web";
 import { Game, gameProps } from "..";
 
-test("gameplay", () => {
+test("gameplay", async () => {
   const initInputs = {
     pointer: {
       pressed: false,
@@ -50,7 +50,7 @@ test("gameplay", () => {
 
   expect(audio.play).toBeCalledWith("boop.wav");
 
-  jumpToFrame(() => getTexture("icon").props.x > 99.99);
+  await jumpToFrame(() => getTexture("icon").props.x > 99.99);
 
   expect(getTexture("icon").props.y).toBeCloseTo(100);
 

--- a/packages/replay-starter-ts/jest.config.js
+++ b/packages/replay-starter-ts/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   testMatch: ["**/__tests__/**/*.test.ts"],
   transformIgnorePatterns: ["/node_modules/(?!@replay/).+\\.js$"],
   globals: { ASSET_NAMES: {} },
+  testTimeout: 30000,
 };

--- a/packages/replay-starter-ts/src/__tests__/game.test.ts
+++ b/packages/replay-starter-ts/src/__tests__/game.test.ts
@@ -3,7 +3,7 @@ import { WebInputs, mapInputCoordinates } from "@replay/web";
 import { iOSInputs } from "@replay/swift";
 import { Game, gameProps } from "..";
 
-test("gameplay", () => {
+test("gameplay", async () => {
   const initInputs: WebInputs | iOSInputs = {
     pointer: {
       pressed: false,
@@ -51,7 +51,7 @@ test("gameplay", () => {
 
   expect(audio.play).toBeCalledWith("boop.wav");
 
-  jumpToFrame(() => getTexture("icon").props.x > 99.99);
+  await jumpToFrame(() => getTexture("icon").props.x > 99.99);
 
   expect(getTexture("icon").props.y).toBeCloseTo(100);
 

--- a/packages/replay-test/jest.config.js
+++ b/packages/replay-test/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: "ts-jest/presets/js-with-ts",
   testEnvironment: "node",
   testMatch: ["**/__tests__/**/*.test.ts"],
+  testTimeout: 30000,
 };

--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -500,7 +500,7 @@ test("jumpToFrame throws last error", async () => {
     initInputs: {},
   });
 
-  expect.assertions(1);
+  expect.assertions(2);
 
   try {
     await jumpToFrame(() => getTexture("i-dont-exist"));
@@ -508,6 +508,10 @@ test("jumpToFrame throws last error", async () => {
     expect(e.message).toBe(
       `Timeout of 1000 gameplay seconds reached on jumpToFrame with error:\n\nNo textures found with test id "i-dont-exist"`
     );
+    // First line of stack is the code in this file
+    expect(
+      e.stack.split("\n")[1].includes("src/__tests__/replay-test.test.ts")
+    ).toBe(true);
   }
 });
 

--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -200,7 +200,7 @@ test("getByText", () => {
 
   nextFrame();
   expect(getByText("x: 2").length).toBe(1);
-  expect(() => getByText("x: 1")).toThrowError();
+  expect(getByText("x: 1").length).toBe(0);
 });
 
 test("now", () => {
@@ -462,7 +462,7 @@ test("can test individual Sprites", () => {
   );
 
   expect(getTextures().length).toBe(1);
-  expect(getByText("Hello")).toBeTruthy();
+  expect(getByText("Hello").length).toBe(1);
 });
 
 test("can map input coordinates to relative coordinates within Sprite", () => {

--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -111,14 +111,14 @@ test("getTextures, nextFrame", () => {
   `);
 });
 
-test("jumpToFrame, getTexture", () => {
+test("jumpToFrame, getTexture", async () => {
   const { jumpToFrame, getTexture } = testSprite(Game(gameProps), gameProps, {
     initInputs: {
       pressed: true,
     },
   });
 
-  jumpToFrame(() => getTexture("player").props.x > 10);
+  await jumpToFrame(() => getTexture("player").props.x > 10);
 
   expect(getTexture("player").props.x).toBe(11);
 });
@@ -495,14 +495,20 @@ test("can get global position and rotation of deeply nested textures", () => {
   expect(textures[0].props.rotation).toBe(0);
 });
 
-test("jumpToFrame throws last error", () => {
+test("jumpToFrame throws last error", async () => {
   const { jumpToFrame, getTexture } = testSprite(Game(gameProps), gameProps, {
     initInputs: {},
   });
 
-  expect(() => jumpToFrame(() => getTexture("i-dont-exist"))).toThrowError(
-    `Timeout of 1000 gameplay seconds reached on jumpToFrame with error:\n\nNo textures found with test id "i-dont-exist"`
-  );
+  expect.assertions(1);
+
+  try {
+    await jumpToFrame(() => getTexture("i-dont-exist"));
+  } catch (e) {
+    expect(e.message).toBe(
+      `Timeout of 1000 gameplay seconds reached on jumpToFrame with error:\n\nNo textures found with test id "i-dont-exist"`
+    );
+  }
 });
 
 test("can mock Native Sprites", () => {

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -502,18 +502,14 @@ export function testSprite<P, S, I>(
 
   /**
    * Get an array of text textures which include text content. Case insensitive.
-   * Throws if no matches found.
+   * Returns empty array if no matches found.
    */
   function getByText(text: string) {
-    const matches = textures
+    return textures
       .filter(isTextTexture)
       .filter((texture) =>
         texture.props.text.toLowerCase().includes(text.toLowerCase())
       );
-    if (matches.length === 0) {
-      throw Error(`No text textures found with content "${text}"`);
-    }
-    return matches;
   }
 
   // Init render

--- a/website/docs/test.md
+++ b/website/docs/test.md
@@ -109,7 +109,7 @@ expect(textureExists("player")).toBe(true);
 
 ### `getByText(text)`
 
-Get a text Texture based on its text content. Returns an array of all matches, throws if there are no matches.
+Get an array of text Textures which include text content. Case insensitive. Returns empty array if no matches found.
 
 ```js
 const scoreLabel = getByText("Score: 10")[0];

--- a/website/docs/test.md
+++ b/website/docs/test.md
@@ -48,10 +48,12 @@ nextFrame();
 
 ### `jumpToFrame(() => condition)`
 
-Synchronously progress frames of the game until condition is met and no errors are thrown. Condition can also return a Texture (useful for throwing methods like `getByText`). Throws if 1000 gameplay seconds (60,000 loops) pass and condition not met / still errors.
+Asynchronously progress frames of the game until condition is met and no errors are thrown. Condition can also return a Texture (useful for throwing methods like `getTexture`). Rejects if 1000 gameplay seconds (60,000 loops) pass and condition not met / still errors.
+
+Note that this will run at almost synchronous speed, but doesn't block the event loop.
 
 ```js
-jumpToFrame(() => props.x > 10);
+await jumpToFrame(() => props.x > 10);
 ```
 
 ### `setRandomNumbers(array)`

--- a/website/docs/tutorial/20.md
+++ b/website/docs/tutorial/20.md
@@ -6,6 +6,6 @@ Using [Jest](https://jestjs.io/) we can write an initial test to confirm we can 
 
 In `__tests__/game.test` replace what's there with the code on the right. We pass our `Game` Sprite (and `gameProps`) into the `testSprite` function, which returns some more useful functions for inspecting our game. Since the test platform doesn't know if we want to run on web or iOS, we need to supply the inputs we'd expect on those platforms through `initInputs`.
 
-Below that `getByText(mainMenuText)` searches all `t.text` Textures that match the string passed in, or throws an error if it can't find it. This confirms that our main menu is visible on the initial render.
+Below that `getByText(mainMenuText)` searches all `t.text` Textures that match the string passed in. This confirms that our main menu is visible on the initial render.
 
 Next we call `updateInputs` to simulate a mouse click or tap to start, then progress one frame with `nextFrame`. After that we reset the inputs and progress one more frame. Now that the game's started, we confirm in our test the main menu isn't visible any more.

--- a/website/src/tutorial/20/js/__tests__/game.test.js
+++ b/website/src/tutorial/20/js/__tests__/game.test.js
@@ -24,7 +24,7 @@ test("Can start game", () => {
     }
   );
 
-  expect(getByText(mainMenuText)).toBeDefined();
+  expect(getByText(mainMenuText).length).toBe(1);
 
   updateInputs({
     pointer: {
@@ -44,5 +44,5 @@ test("Can start game", () => {
   nextFrame();
 
   // Main menu gone, game has started
-  expect(() => getByText(mainMenuText)).toThrowError();
+  expect(getByText(mainMenuText).length).toBe(0);
 });

--- a/website/src/tutorial/20/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/20/ts/__tests__/game.test.ts
@@ -26,7 +26,7 @@ test("Can start game", () => {
     }
   );
 
-  expect(getByText(mainMenuText)).toBeDefined();
+  expect(getByText(mainMenuText).length).toBe(1);
 
   updateInputs({
     pointer: {
@@ -46,5 +46,5 @@ test("Can start game", () => {
   nextFrame();
 
   // Main menu gone, game has started
-  expect(() => getByText(mainMenuText)).toThrowError();
+  expect(getByText(mainMenuText).length).toBe(0);
 });

--- a/website/src/tutorial/21/js/__tests__/game.test.js
+++ b/website/src/tutorial/21/js/__tests__/game.test.js
@@ -3,7 +3,7 @@ import { Game, gameProps } from "..";
 import { pipeGap } from "../pipe";
 import { birdHeight } from "../bird";
 
-test("Can reach a score of 2", () => {
+test("Can reach a score of 2", async () => {
   const initInputs = {
     pointer: {
       pressed: false,
@@ -77,7 +77,7 @@ test("Can reach a score of 2", () => {
     nextFrame();
   }
 
-  jumpToFrame(() => {
+  await jumpToFrame(() => {
     keepBirdInMiddle();
 
     // Exit when main menu appears again

--- a/website/src/tutorial/21/js/__tests__/game.test.js
+++ b/website/src/tutorial/21/js/__tests__/game.test.js
@@ -31,7 +31,7 @@ test("Can reach a score of 2", async () => {
     initRandom: [0.5, 0.5, 0],
   });
 
-  expect(getByText(mainMenuText)).toBeDefined();
+  expect(getByText(mainMenuText).length).toBe(1);
 
   updateInputs({
     pointer: {
@@ -51,7 +51,7 @@ test("Can reach a score of 2", async () => {
   nextFrame();
 
   // Main menu gone, game has started
-  expect(() => getByText(mainMenuText)).toThrowError();
+  expect(getByText(mainMenuText).length).toBe(0);
 
   // Keeps the bird hovering in the middle to pass the first 2 pipes
   function keepBirdInMiddle() {
@@ -81,7 +81,7 @@ test("Can reach a score of 2", async () => {
     keepBirdInMiddle();
 
     // Exit when main menu appears again
-    return getByText(mainMenuText)[0];
+    return getByText(mainMenuText).length > 0;
   });
 
   getByText("Score: 2");

--- a/website/src/tutorial/21/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/21/ts/__tests__/game.test.ts
@@ -33,7 +33,7 @@ test("Can reach a score of 2", async () => {
     initRandom: [0.5, 0.5, 0],
   });
 
-  expect(getByText(mainMenuText)).toBeDefined();
+  expect(getByText(mainMenuText).length).toBe(1);
 
   updateInputs({
     pointer: {
@@ -53,7 +53,7 @@ test("Can reach a score of 2", async () => {
   nextFrame();
 
   // Main menu gone, game has started
-  expect(() => getByText(mainMenuText)).toThrowError();
+  expect(getByText(mainMenuText).length).toBe(0);
 
   // Keeps the bird hovering in the middle to pass the first 2 pipes
   function keepBirdInMiddle() {
@@ -83,7 +83,7 @@ test("Can reach a score of 2", async () => {
     keepBirdInMiddle();
 
     // Exit when main menu appears again
-    return getByText(mainMenuText)[0];
+    return getByText(mainMenuText).length > 0;
   });
 
   getByText("Score: 2");

--- a/website/src/tutorial/21/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/21/ts/__tests__/game.test.ts
@@ -5,7 +5,7 @@ import { Game, gameProps } from "..";
 import { pipeGap } from "../pipe";
 import { birdHeight } from "../bird";
 
-test("Can reach a score of 2", () => {
+test("Can reach a score of 2", async () => {
   const initInputs: WebInputs | iOSInputs = {
     pointer: {
       pressed: false,
@@ -79,7 +79,7 @@ test("Can reach a score of 2", () => {
     nextFrame();
   }
 
-  jumpToFrame(() => {
+  await jumpToFrame(() => {
     keepBirdInMiddle();
 
     // Exit when main menu appears again

--- a/website/src/tutorial/22/js/src/__tests__/game.test.js
+++ b/website/src/tutorial/22/js/src/__tests__/game.test.js
@@ -3,7 +3,7 @@ import { Game, gameProps } from "..";
 import { pipeGap } from "../pipe";
 import { birdHeight } from "../bird";
 
-test("Can reach a score of 2", () => {
+test("Can reach a score of 2", async () => {
   const initInputs = {
     pointer: {
       pressed: false,
@@ -77,7 +77,7 @@ test("Can reach a score of 2", () => {
     nextFrame();
   }
 
-  jumpToFrame(() => {
+  await jumpToFrame(() => {
     keepBirdInMiddle();
 
     // Exit when main menu appears again

--- a/website/src/tutorial/22/js/src/__tests__/game.test.js
+++ b/website/src/tutorial/22/js/src/__tests__/game.test.js
@@ -31,7 +31,7 @@ test("Can reach a score of 2", async () => {
     initRandom: [0.5, 0.5, 0],
   });
 
-  expect(getByText(mainMenuText)).toBeDefined();
+  expect(getByText(mainMenuText).length).toBe(1);
 
   updateInputs({
     pointer: {
@@ -51,7 +51,7 @@ test("Can reach a score of 2", async () => {
   nextFrame();
 
   // Main menu gone, game has started
-  expect(() => getByText(mainMenuText)).toThrowError();
+  expect(getByText(mainMenuText).length).toBe(0);
 
   // Keeps the bird hovering in the middle to pass the first 2 pipes
   function keepBirdInMiddle() {
@@ -81,7 +81,7 @@ test("Can reach a score of 2", async () => {
     keepBirdInMiddle();
 
     // Exit when main menu appears again
-    return getByText(mainMenuText)[0];
+    return getByText(mainMenuText).length > 0;
   });
 
   getByText("Score: 2");

--- a/website/src/tutorial/22/ts/src/__tests__/game.test.ts
+++ b/website/src/tutorial/22/ts/src/__tests__/game.test.ts
@@ -33,7 +33,7 @@ test("Can reach a score of 2", async () => {
     initRandom: [0.5, 0.5, 0],
   });
 
-  expect(getByText(mainMenuText)).toBeDefined();
+  expect(getByText(mainMenuText).length).toBe(1);
 
   updateInputs({
     pointer: {
@@ -53,7 +53,7 @@ test("Can reach a score of 2", async () => {
   nextFrame();
 
   // Main menu gone, game has started
-  expect(() => getByText(mainMenuText)).toThrowError();
+  expect(getByText(mainMenuText).length).toBe(0);
 
   // Keeps the bird hovering in the middle to pass the first 2 pipes
   function keepBirdInMiddle() {
@@ -83,7 +83,7 @@ test("Can reach a score of 2", async () => {
     keepBirdInMiddle();
 
     // Exit when main menu appears again
-    return getByText(mainMenuText)[0];
+    return getByText(mainMenuText).length > 0;
   });
 
   getByText("Score: 2");

--- a/website/src/tutorial/22/ts/src/__tests__/game.test.ts
+++ b/website/src/tutorial/22/ts/src/__tests__/game.test.ts
@@ -5,7 +5,7 @@ import { Game, gameProps } from "..";
 import { pipeGap } from "../pipe";
 import { birdHeight } from "../bird";
 
-test("Can reach a score of 2", () => {
+test("Can reach a score of 2", async () => {
   const initInputs: WebInputs | iOSInputs = {
     pointer: {
       pressed: false,
@@ -79,7 +79,7 @@ test("Can reach a score of 2", () => {
     nextFrame();
   }
 
-  jumpToFrame(() => {
+  await jumpToFrame(() => {
     keepBirdInMiddle();
 
     // Exit when main menu appears again


### PR DESCRIPTION
**Breaking changes.** This changes `jumpToFrame` to be async to avoid blocking the event loop. It also stops `getByText` throwing errors.