### PR TITLE
Add getState to Sprite init method

### DIFF
--- a/packages/replay-core/src/__tests__/utils.ts
+++ b/packages/replay-core/src/__tests__/utils.ts
@@ -145,7 +145,7 @@ export function getTestPlatform(customSize?: DeviceSize) {
     random: jest.fn(() => 0.5),
     timer: {
       start(callback) {
-        callback();
+        setImmediate(callback);
         return "id";
       },
       cancel: jest.fn(),
@@ -204,6 +204,10 @@ export const nativeSpriteSettings: NativeSpriteSettings = {
     gameYToPlatformY: (y) => y,
   },
 };
+
+export function waitFrame() {
+  return new Promise((res) => setImmediate(res));
+}
 
 interface TestGameState {
   position: number;
@@ -358,12 +362,13 @@ export const FullTestGame = makeSprite<
   FullTestGameState,
   TestPlatformInputs
 >({
-  init({ updateState, device }) {
+  init({ updateState, getState, device }) {
     device.timer.start(() => {
       updateState((state) => ({
         ...state,
         testInitUpdateState: "initialised",
       }));
+      device.log(`getState position: ${getState().position}`);
     }, 100);
 
     return {
@@ -754,6 +759,19 @@ const CallbackPropSprite = makeSprite<{
 
   render() {
     return [null];
+  },
+});
+
+/// -- Test getState
+
+export const GetStateGame = makeSprite<GameProps, undefined>({
+  init({ getState }) {
+    getState();
+    return undefined;
+  },
+
+  render() {
+    return [];
   },
 });
 

--- a/packages/replay-core/src/core.ts
+++ b/packages/replay-core/src/core.ts
@@ -395,16 +395,23 @@ function createCustomSpriteContainer<P, S, I>(
     updateStateQueue.push(update);
   };
 
+  let spriteContainer: null | CustomSpriteContainer<P, S, I> = null;
   let initState;
   if (spriteObj.init) {
     initState = spriteObj.init({
       props: initProps,
+      getState: () => {
+        if (!spriteContainer) {
+          throw Error("Cannot call getState synchronously in init");
+        }
+        return spriteContainer.state;
+      },
       device: initDevice,
       updateState,
     });
   }
 
-  return {
+  spriteContainer = {
     type: "custom",
     // WARNING: types are a bit tricky here, need to cast.
     // If a sprite does not set an init state, this will simply pass undefined
@@ -460,6 +467,7 @@ function createCustomSpriteContainer<P, S, I>(
       return sprites;
     },
   };
+  return spriteContainer;
 }
 
 type RenderMethod = "render" | "renderP" | "renderXL" | "renderPXL";

--- a/packages/replay-core/src/sprite.ts
+++ b/packages/replay-core/src/sprite.ts
@@ -66,6 +66,11 @@ interface SpriteObjInit<P, S, I> {
    */
   init: (params: {
     props: Readonly<P>;
+    /**
+     * Access state for asynchronous callbacks. If you call this before `init`
+     * returns it will throw an error.
+     */
+    getState: () => S;
     device: Device<I>;
     updateState: (update: (state: S) => S) => void;
   }) => S;

--- a/website/docs/sprites.md
+++ b/website/docs/sprites.md
@@ -226,10 +226,14 @@ All Sprite methods have the following parameters:
 Called on initial load of Sprite. Use this to run anything you need on setup. Returns the initial state.
 
 ```js
-  init({ props, device, updateState }) {
+  init({ props, device, updateState, getState }) {
     return { ... };
   },
 ```
+
+#### Additional Parameters
+
+- `getState`: A function which returns the current state of the Sprite for asynchronous callbacks. If you call this before `init` returns it will throw an error.
 
 ### `loop`
 


### PR DESCRIPTION
This allows `state` to be accessed from the `init` method in callbacks that rely on it.

e.g:

```js
  init({ getState }) {
    function onLogin() {
      console.log("Successful login", getState().name);
    }
    Backend.login(onLogin);
    return { name: "X" };
  }
```