### PR TITLE
Update number of frames run in jumpToFrame

### DIFF
--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -500,18 +500,32 @@ test("jumpToFrame throws last error", async () => {
     initInputs: {},
   });
 
-  expect.assertions(2);
+  expect.assertions(4);
 
   try {
     await jumpToFrame(() => getTexture("i-dont-exist"));
   } catch (e) {
     expect(e.message).toBe(
-      `Timeout of 1000 gameplay seconds reached on jumpToFrame with error:\n\nNo textures found with test id "i-dont-exist"`
+      `Timeout of 30 gameplay seconds reached on jumpToFrame with error:\n\nNo textures found with test id "i-dont-exist"`
     );
     // First line of stack is the code in this file
     expect(
       e.stack.split("\n")[1].includes("src/__tests__/replay-test.test.ts")
     ).toBe(true);
+  }
+
+  // Override max frames
+  let frameCount = 0;
+  try {
+    await jumpToFrame(() => {
+      frameCount++;
+      return getTexture("i-dont-exist");
+    }, 3600);
+  } catch (e) {
+    expect(e.message).toBe(
+      `Timeout of 60 gameplay seconds reached on jumpToFrame with error:\n\nNo textures found with test id "i-dont-exist"`
+    );
+    expect(frameCount).toBe(3600);
   }
 });
 

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -81,7 +81,10 @@ interface Options<I> {
 
 interface TestSpriteUtils<I> {
   nextFrame: () => void;
-  jumpToFrame: (condition: () => boolean | Texture) => Promise<void>;
+  jumpToFrame: (
+    condition: () => boolean | Texture,
+    maxFrames?: number
+  ) => Promise<void>;
   setRandomNumbers: (numbers: number[]) => void;
   updateInputs: (newInputs: I) => void;
   getTextures: () => Texture[];
@@ -461,13 +464,16 @@ export function testSprite<P, S, I>(
   /**
    * Asynchronously progress frames of the game until condition is met and no
    * errors are thrown. Condition can also return a Texture (useful for throwing
-   * methods like `getTexture`). Rejects if 1000 gameplay seconds (60,000 loops)
+   * methods like `getTexture`). Rejects if 30 gameplay seconds (1800 frames)
    * pass and condition not met / still errors.
    *
    * Note that this will run at almost synchronous speed, but doesn't block the
    * event loop.
    */
-  async function jumpToFrame(condition: () => boolean | Texture) {
+  async function jumpToFrame(
+    condition: () => boolean | Texture,
+    maxFrames = 1800
+  ) {
     let lastErrorMsg: string | null = null;
 
     // Keep this for improved error stack reporting
@@ -489,12 +495,13 @@ export function testSprite<P, S, I>(
           // continue trying
         }
         i++;
-        if (i < 60000) {
+        if (i < maxFrames) {
           setImmediate(loop);
           return;
         }
-        let errMessage =
-          "Timeout of 1000 gameplay seconds reached on jumpToFrame";
+        let errMessage = `Timeout of ${Math.round(
+          maxFrames / 60
+        )} gameplay seconds reached on jumpToFrame`;
         if (lastErrorMsg) {
           errMessage += ` with error:\n\n${lastErrorMsg}`;
         }

--- a/website/docs/test.md
+++ b/website/docs/test.md
@@ -46,9 +46,14 @@ Increment game by one frame.
 nextFrame();
 ```
 
-### `jumpToFrame(() => condition)`
+### `jumpToFrame(condition, maxFrames)`
 
-Asynchronously progress frames of the game until condition is met and no errors are thrown. Condition can also return a Texture (useful for throwing methods like `getTexture`). Rejects if 1000 gameplay seconds (60,000 loops) pass and condition not met / still errors.
+#### Parameters
+
+- `condition`: A function that can return a boolean or throw an error.
+- `maxFrames`: (Optional) Set the maximum number of frames that will run. Default `1800`.
+
+Asynchronously progress frames of the game until condition is met and no errors are thrown. Condition can also return a Texture (useful for throwing methods like `getTexture`). Rejects if 30 gameplay seconds (1800 frames) pass and condition not met / still errors.
 
 Note that this will run at almost synchronous speed, but doesn't block the event loop.
 


### PR DESCRIPTION
**Breaking Change**. This reduces the default number of frames `jumpToFrame` runs for to avoid tests taking a long time to fail. But the setting can be overridden through the `maxFrames` argument.