### PR TITLE
Throw error on duplicate Sprite IDs

### DIFF
--- a/packages/replay-core/src/__tests__/replay-core.test.ts
+++ b/packages/replay-core/src/__tests__/replay-core.test.ts
@@ -23,6 +23,7 @@ import {
   waitFrame,
   GetStateGame,
   AssetsGame,
+  DuplicateSpriteIdsGame,
 } from "./utils";
 import { SpriteTextures, NativeSpriteUtils } from "../sprite";
 import { TextTexture, CircleTexture, RectangleTexture } from "../t";
@@ -1045,6 +1046,20 @@ test("Sprite unmounted before it loads", async () => {
 
   // Image not in memory
   expect("a.png" in mutableTestDevice.assetUtils.imageElements).toBe(false);
+});
+
+test("throws error on duplicate Sprites", () => {
+  const { platform } = getTestPlatform();
+
+  const { getNextFrameTextures } = replayCore(
+    platform,
+    nativeSpriteSettings,
+    DuplicateSpriteIdsGame(gameProps)
+  );
+
+  expect(() => {
+    getNextFrameTextures(1000 / 60, jest.fn());
+  }).toThrowError("Duplicate Sprite id TestSprite");
 });
 
 test("supports Pure Sprites", () => {

--- a/packages/replay-core/src/__tests__/utils.ts
+++ b/packages/replay-core/src/__tests__/utils.ts
@@ -855,6 +855,23 @@ export const GetStateGame = makeSprite<GameProps, undefined>({
   },
 });
 
+/// -- Test Duplicate Sprite IDs
+
+export const DuplicateSpriteIdsGame = makeSprite<GameProps>({
+  render() {
+    return [
+      TestSprite({
+        id: "TestSprite",
+        initPos: 0,
+      }),
+      TestSprite({
+        id: "TestSprite",
+        initPos: 0,
+      }),
+    ];
+  },
+});
+
 /// -- Test Pure Sprites
 
 export const PureSpriteGame = makeSprite<

--- a/packages/replay-core/src/core.ts
+++ b/packages/replay-core/src/core.ts
@@ -216,6 +216,14 @@ function traverseCustomSpriteContainer<P, I>(
   const unusedChildIds = new Set(customSpriteContainer.prevChildIds);
   const childIds: string[] = [];
 
+  if (unusedChildIds.size < customSpriteContainer.prevChildIds.length) {
+    const duplicate = customSpriteContainer.prevChildIds.find(
+      (item, index) =>
+        customSpriteContainer.prevChildIds.indexOf(item) !== index
+    );
+    throw Error(`Duplicate Sprite id ${duplicate}`);
+  }
+
   const textures = sprites
     .map(function mapTextures(sprite) {
       if (!sprite) return sprite;


### PR DESCRIPTION
For https://github.com/edbentley/replay/issues/57

Managed to find a way to detect duplicate Sprite IDs with minimal runtime impact.