### PR TITLE
Fix pressing on iOS text input regression

### DIFF
--- a/packages/replay-swift/Replay/Sources/Replay/ReplayWebView.swift
+++ b/packages/replay-swift/Replay/Sources/Replay/ReplayWebView.swift
@@ -40,7 +40,7 @@ class ReplayWebViewManager: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNa
         
         // Disable haptic feedback on long press
         let longPress = UILongPressGestureRecognizer(target: nil, action: nil)
-        longPress.minimumPressDuration = 0
+        longPress.minimumPressDuration = 0.1
         webView.addGestureRecognizer(longPress)
         
         // Load in game


### PR DESCRIPTION
This fixes a regression from #60 where text inputs couldn't be tapped on iOS. Don't ask me why this works. 🤷‍♂️ 