### PR TITLE
Web: Ignore repeat keys held down

### DIFF
--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -115,7 +115,7 @@ export function renderCanvas<S>(
   let totalPageNotVisibleTime = 0;
 
   const keyDownHandler = (e: KeyboardEvent) => {
-    if (!isInFocus) return;
+    if (!isInFocus || e.repeat) return;
     inputKeyDownHandler(e);
   };
   const keyUpHandler = (e: KeyboardEvent) => {


### PR DESCRIPTION
Previously `device.inputs.keysJustPressed` would flicker on and off for a key when held down, due to keyboards repeating keys when held down. This change disables that, which I think is preferred for building games.