### PR TITLE
Update audio play and include overwrite field

### DIFF
--- a/packages/replay-core/src/__tests__/replay-core.test.ts
+++ b/packages/replay-core/src/__tests__/replay-core.test.ts
@@ -543,7 +543,11 @@ test("supports playing audio", () => {
 
   mutableTestDevice.inputs.buttonPressed.sound.playLoop = true;
   getNextFrameTexturesOverTime();
-  expect(audioSpy.play).toBeCalledWith(0, true);
+  expect(audioSpy.play).toBeCalledWith({ fromPosition: 0, loop: true });
+
+  mutableTestDevice.inputs.buttonPressed.sound.playOverwrite = true;
+  getNextFrameTexturesOverTime();
+  expect(audioSpy.play).toBeCalledWith({ overwrite: true });
 
   mutableTestDevice.inputs.buttonPressed.sound.pause = true;
   getNextFrameTexturesOverTime();

--- a/packages/replay-core/src/__tests__/utils.ts
+++ b/packages/replay-core/src/__tests__/utils.ts
@@ -44,6 +44,7 @@ interface TestPlatformInputs {
       play: boolean;
       playFromPosition: boolean;
       playLoop: boolean;
+      playOverwrite: boolean;
       pause: boolean;
       getPosition: boolean;
     };
@@ -85,6 +86,7 @@ function getInitTestPlatformInputs(): TestPlatformInputs {
         play: false,
         playFromPosition: false,
         playLoop: false,
+        playOverwrite: false,
         pause: false,
         getPosition: false,
       },
@@ -434,7 +436,10 @@ export const FullTestGame = makeSprite<
       device.audio("filename").play(100);
     }
     if (device.inputs.buttonPressed.sound.playLoop) {
-      device.audio("filename").play(0, true);
+      device.audio("filename").play({ fromPosition: 0, loop: true });
+    }
+    if (device.inputs.buttonPressed.sound.playOverwrite) {
+      device.audio("filename").play({ overwrite: true });
     }
     if (device.inputs.buttonPressed.sound.pause) {
       device.audio("filename").pause();

--- a/packages/replay-core/src/device.ts
+++ b/packages/replay-core/src/device.ts
@@ -62,7 +62,11 @@ export interface Device<I = unknown> {
      * Current time in audio track in seconds
      */
     getPosition: () => number;
-    play: (fromPosition?: number, loop?: boolean) => void;
+    play: (
+      fromPositionOrSettings?:
+        | number
+        | { fromPosition?: number; loop?: boolean; overwrite?: boolean }
+    ) => void;
     pause: () => void;
   };
 

--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -371,7 +371,10 @@ test("audio", async () => {
     testInput: "audioPlayLoop",
   });
   nextFrame();
-  expect(audio.play).toBeCalledWith("sound.wav", 0, true);
+  expect(audio.play).toBeCalledWith("sound.wav", {
+    fromPosition: 0,
+    loop: true,
+  });
 
   updateInputs({
     testInput: "audioPause",
@@ -704,7 +707,7 @@ const Game = makeSprite<GameProps, State, Inputs>({
         device.audio("sound.wav").play(100);
         break;
       case "audioPlayLoop":
-        device.audio("sound.wav").play(0, true);
+        device.audio("sound.wav").play({ fromPosition: 0, loop: true });
         break;
       case "audioPause":
         device.audio("sound.wav").pause();

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -295,13 +295,11 @@ export function testSprite<P, S, I>(
     }
     return {
       getPosition: () => audio.getPosition(filename),
-      play: (fromPosition, loop) => {
-        if (loop !== undefined) {
-          audio.play(filename, fromPosition, loop);
-        } else if (fromPosition !== undefined) {
-          audio.play(filename, fromPosition);
-        } else {
+      play: (fromPositionOrSettings) => {
+        if (fromPositionOrSettings === undefined) {
           audio.play(filename);
+        } else {
+          audio.play(filename, fromPositionOrSettings);
         }
       },
       pause: () => audio.pause(filename),

--- a/packages/replay-web/src/device.ts
+++ b/packages/replay-web/src/device.ts
@@ -94,8 +94,8 @@ export function getAudio(
         // If the sound is already playing, we fire and forget a new one unless
         // we want to overwrite it.
         if (!soundIsAlreadyPlaying || overwrite) {
-          // Stop other sound if it exists
-          if (playState) {
+          // Stop other sound if it exists and is playing
+          if (playState && soundIsAlreadyPlaying) {
             playState.sample.onended = null;
             playState.sample.stop();
           }

--- a/website/docs/device.md
+++ b/website/docs/device.md
@@ -124,10 +124,24 @@ The returned object has the following methods:
 
 #### `play`
 
-Play the sound file. `position` and `loop` arguments are optional.
+Play the sound file. If the sound is already playing, another sound will be played at the same time (unless `overwrite` is set to `true`).
+
+The first argument is optional and can be a number (start time in seconds) or an object with the following fields:
+
+- `fromPosition`: (Optional) Where to start the sound file from, same as providing the first argument as a number.
+- `overwrite`: (Optional) If this sound is already playing, remove it first. Default `false`.
+- `loop`: (Optional) Keep playing the sound when it finishes. Default `false`.
+
+If no argument is provided, the sound will continue from where it was paused, or from the beginning if it's the first time it's played / being played in parallel and `overwrite` is not set to `true`.
 
 ```js
-mySound.play(position = 0, loop = false);
+mySound.play();
+
+mySound.play(10);
+
+mySound.play({ overwrite: true });
+
+mySound.play({ fromPosition: 10, overwrite: true, loop: true });
 ```
 
 #### `pause`

--- a/website/docs/device.md
+++ b/website/docs/device.md
@@ -124,15 +124,20 @@ The returned object has the following methods:
 
 #### `play`
 
-Play the sound file. If the sound is already playing, another sound will be played at the same time (unless `overwrite` is set to `true`).
+Play the audio file. If the file is already playing, another sound will be played at the same time (unless `overwrite` is set to `true`).
 
 The first argument is optional and can be a number (start time in seconds) or an object with the following fields:
 
-- `fromPosition`: (Optional) Where to start the sound file from, same as providing the first argument as a number.
-- `overwrite`: (Optional) If this sound is already playing, remove it first. Default `false`.
-- `loop`: (Optional) Keep playing the sound when it finishes. Default `false`.
+- `fromPosition`: (Optional) Where to start the audio file from in seconds, same as providing the first argument as a number.
+- `overwrite`: (Optional) If this audio file is already playing, remove it first. Default `false`.
+- `loop`: (Optional) Keep playing the audio when it finishes. Default `false`.
 
-If no argument is provided, the sound will continue from where it was paused, or from the beginning if it's the first time it's played / being played in parallel and `overwrite` is not set to `true`.
+If no argument is provided or `fromPosition` is not defined in the argument object:
+
+- The audio will play from the beginning if:
+  - It's the first time being played, or
+  - The audio is already playing and `overwrite` is not set to `true`.
+- Otherwise, the audio will continue from where it was paused.
 
 ```js
 mySound.play();
@@ -146,7 +151,7 @@ mySound.play({ fromPosition: 10, overwrite: true, loop: true });
 
 #### `pause`
 
-Pause the sound file.
+Pause the sound.
 
 ```js
 mySound.pause();


### PR DESCRIPTION
**Breaking change**. This refactors `audio("filename").play` to allow more fields to passed in.

Also adds a new field `overwrite` to ensure the same sound file can't be played twice (e.g. background music). Previously trying to pause and play the sound in one frame would not work.