### PR TITLE
Support nested updateState calls

### DIFF
--- a/packages/replay-core/src/__tests__/replay-core.test.ts
+++ b/packages/replay-core/src/__tests__/replay-core.test.ts
@@ -478,6 +478,39 @@ test("updateState in loop will update state in next render", () => {
   expect((spriteTextures.textures[0] as CircleTexture).props.x).toEqual(11);
 });
 
+test("can call updateState within an updateState", async () => {
+  const { platform, mutableTestDevice } = getTestPlatform();
+  const logSpy = jest.spyOn(mutableTestDevice, "log");
+
+  mutableTestDevice.inputs.buttonPressed.action = true;
+
+  const { initTextures, getNextFrameTextures } = replayCore(
+    platform,
+    nativeSpriteSettings,
+    FullTestGame(gameProps)
+  );
+
+  expect((initTextures.textures[1] as TextTexture).props.text).toBe(
+    "updateState Counter: 0"
+  );
+
+  let time = 1;
+  const getNextFrameTexturesOverTime = () => {
+    time += 1000 * (1 / 60);
+    return getNextFrameTextures(time, jest.fn());
+  };
+
+  const spriteTextures = getNextFrameTexturesOverTime();
+
+  expect((spriteTextures.textures[1] as TextTexture).props.text).toBe(
+    "updateState Counter: 3"
+  );
+
+  expect(logSpy).toBeCalledWith("First updateState counter val: 0");
+  expect(logSpy).toBeCalledWith("Second updateState counter val: 1");
+  expect(logSpy).toBeCalledWith("Third updateState counter val: 2");
+});
+
 test("supports getState", async () => {
   const { platform, mutableTestDevice } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");

--- a/packages/replay-core/src/__tests__/utils.ts
+++ b/packages/replay-core/src/__tests__/utils.ts
@@ -359,6 +359,7 @@ const MultipleRendersSprite = makeSprite({
 
 interface FullTestGameState {
   position: number;
+  testNestedUpdateStateCounter: number;
   testInitUpdateState?: string;
   testRenderUpdateState?: string;
   testRenderUpdateState2?: string;
@@ -384,6 +385,7 @@ export const FullTestGame = makeSprite<
 
     return {
       position: 5,
+      testNestedUpdateStateCounter: 0,
     };
   },
 
@@ -405,6 +407,34 @@ export const FullTestGame = makeSprite<
           testRenderTimeout: "updateState from timeout in render",
         }));
       }, 1000);
+
+      updateState((s1) => {
+        updateState((s2) => {
+          updateState((s3) => {
+            device.log(
+              `Third updateState counter val: ${s3.testNestedUpdateStateCounter}`
+            );
+            return {
+              ...s3,
+              testNestedUpdateStateCounter: s3.testNestedUpdateStateCounter + 1,
+            };
+          });
+          device.log(
+            `Second updateState counter val: ${s2.testNestedUpdateStateCounter}`
+          );
+          return {
+            ...s2,
+            testNestedUpdateStateCounter: s2.testNestedUpdateStateCounter + 1,
+          };
+        });
+        device.log(
+          `First updateState counter val: ${s1.testNestedUpdateStateCounter}`
+        );
+        return {
+          ...s1,
+          testNestedUpdateStateCounter: s1.testNestedUpdateStateCounter + 1,
+        };
+      });
     }
 
     if (device.inputs.buttonPressed.log) {
@@ -522,6 +552,7 @@ export const FullTestGame = makeSprite<
 
     return {
       position: state.position + posInc,
+      testNestedUpdateStateCounter: state.testNestedUpdateStateCounter,
     };
   },
 
@@ -533,6 +564,10 @@ export const FullTestGame = makeSprite<
         rotation: 0,
         radius: 10,
         color: "#0095DD",
+      }),
+      t.text({
+        text: `updateState Counter: ${state.testNestedUpdateStateCounter}`,
+        color: "black",
       }),
     ];
   },

--- a/packages/replay-core/src/core.ts
+++ b/packages/replay-core/src/core.ts
@@ -455,10 +455,17 @@ function createCustomSpriteContainer<P, S, I>(
     loadFilesPromise,
     getSprites(props, device, initCreation, renderMethod, extrapolateFactor) {
       const runUpdateStateCallbacks = () => {
-        this.state = updateStateQueue.reduce(
-          (state, update) => update(state),
-          this.state
-        );
+        let queueIndex = 0;
+
+        // Use a while loop in case nested updateStates add to the array during
+        // loop
+        while (queueIndex < updateStateQueue.length) {
+          const update = updateStateQueue[queueIndex];
+
+          this.state = update(this.state);
+
+          queueIndex++;
+        }
         updateStateQueue.length = 0;
       };
 


### PR DESCRIPTION
Previously calling `updateState` within another `updateState` would not ever get called. This PR ensures all nested `updateState` calls will run.