### PR TITLE
Async Storage

### DIFF
--- a/dev-game/src/__tests__/game.test.ts
+++ b/dev-game/src/__tests__/game.test.ts
@@ -31,7 +31,7 @@ test("gameplay", async () => {
     audio,
     store,
     log,
-    loadFiles,
+    resolvePromises,
     // alert,
     // clipboard,
   } = testSprite(Game(gameProps), gameProps, {
@@ -50,6 +50,9 @@ test("gameplay", async () => {
 
   expect(getByText("Loading game").length).toBe(1);
 
+  // Wait for storage promise to resolve
+  await resolvePromises();
+
   // Wait for initial timeout of 1000 ms
   for (let i = 0; i <= 60; i++) {
     nextFrame();
@@ -59,7 +62,7 @@ test("gameplay", async () => {
   expect(getByText("Loading level").length).toBe(1);
 
   // Load PlayStage files
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getByText("Loading level").length).toBe(0);

--- a/dev-game/swift/dev-game.xcodeproj/project.pbxproj
+++ b/dev-game/swift/dev-game.xcodeproj/project.pbxproj
@@ -187,7 +187,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if ! which npm > /dev/null; then\n  # Support Nix users\n  PATH=${PATH}:~/.nix-profile/bin\n\n  if ! which npm > /dev/null; then\n    echo \"error: Cannot find npm. Run \\\"which npm\\\" and add the directory to your PATH above.\"\n    exit 1\n  fi\nfi\ncd ${SRCROOT}/..\nnpm --scripts-prepend-node-path=true run build-swift\n";
+			shellScript = "if ! which npm > /dev/null; then\n  # Support Nix users\n  PATH=${PATH}:~/.nix-profile/bin\n\n  if ! which npm > /dev/null; then\n    echo \"error: Cannot find npm. Run \\\"which npm\\\" and add the directory to your PATH above.\"\n    exit 1\n  fi\nfi\ncd ${SRCROOT}/..\nnpm --scripts-prepend-node-path=true run build-swift\n\nsleep 1\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/replay-core/src/__tests__/replay-core.test.ts
+++ b/packages/replay-core/src/__tests__/replay-core.test.ts
@@ -637,13 +637,13 @@ test("supports network calls", () => {
   expect(logSpy).toBeCalledWith("DELETE-/test");
 });
 
-test("supports local storage", () => {
+test("supports local storage", async () => {
   const { platform, mutableTestDevice } = getTestPlatform();
 
   const { storage } = mutableTestDevice;
   const storageSpy = {
-    getStore: jest.spyOn(storage, "getStore"),
-    setStore: jest.spyOn(storage, "setStore"),
+    getItem: jest.spyOn(storage, "getItem"),
+    setItem: jest.spyOn(storage, "setItem"),
   };
 
   const { initTextures, getNextFrameTextures } = replayCore(
@@ -651,9 +651,17 @@ test("supports local storage", () => {
     nativeSpriteSettings,
     LocalStorageGame(gameProps)
   );
-  expect(storageSpy.getStore).toBeCalled();
+  expect(storageSpy.getItem).toBeCalledWith("text1");
+  expect(storageSpy.getItem).toBeCalledWith("text2");
 
-  expect(initTextures.textures).toEqual([
+  expect(initTextures.textures).toEqual([]);
+
+  // Wait for promises to resolve
+  await waitFrame();
+
+  const spriteTextures = getNextFrameTextures(1000 * (1 / 60) + 1, jest.fn());
+
+  expect(spriteTextures.textures).toEqual([
     {
       type: "text",
       props: {
@@ -671,11 +679,25 @@ test("supports local storage", () => {
         font: undefined,
       },
     },
+    {
+      type: "text",
+      props: {
+        text: "storage",
+        color: "blue",
+        x: 0,
+        y: 0,
+        rotation: 0,
+        opacity: 1,
+        anchorX: 0,
+        anchorY: 0,
+        scaleX: 1,
+        scaleY: 1,
+        mask: null,
+      },
+    },
   ]);
 
-  getNextFrameTextures(1000 * (1 / 60) + 1, jest.fn());
-
-  expect(storageSpy.setStore).toBeCalledWith({ text2: "new-val" });
+  expect(storageSpy.setItem).toBeCalledWith("text2", "new-val");
 });
 
 test("supports alerts", () => {

--- a/packages/replay-core/src/__tests__/utils.ts
+++ b/packages/replay-core/src/__tests__/utils.ts
@@ -167,8 +167,8 @@ export function getTestPlatform(customSize?: DeviceSize) {
     },
     network,
     storage: {
-      getStore: jest.fn(() => ({ text1: "storage" })),
-      setStore: jest.fn(),
+      getItem: jest.fn(() => Promise.resolve("storage")),
+      setItem: jest.fn(),
     },
     alert: {
       ok: jest.fn((_, onResponse) => {
@@ -731,8 +731,8 @@ const NestedFirstSprite2 = makeSprite<{}, undefined, TestPlatformInputs>({
 /// -- Test local storage
 
 interface LocalStorageGameState {
-  text1?: string;
-  text2?: string;
+  text1: string | null;
+  text2: string | null;
 }
 
 export const LocalStorageGame = makeSprite<
@@ -740,16 +740,18 @@ export const LocalStorageGame = makeSprite<
   LocalStorageGameState,
   TestPlatformInputs
 >({
-  init({ device }) {
-    const store = device.storage.getStore();
-    return {
-      text1: store.text1,
-      text2: store.text2,
-    };
+  init({ device, updateState }) {
+    Promise.all([
+      device.storage.getItem("text1"),
+      device.storage.getItem("text2"),
+    ]).then(([text1, text2]) => {
+      updateState((s) => ({ ...s, text1, text2 }));
+    });
+    return { text1: null, text2: null };
   },
 
   loop({ device, state }) {
-    device.storage.setStore({ text2: "new-val" });
+    device.storage.setItem("text2", "new-val");
 
     return state;
   },

--- a/packages/replay-core/src/device.ts
+++ b/packages/replay-core/src/device.ts
@@ -89,8 +89,8 @@ export interface Device<I = unknown> {
   };
 
   storage: {
-    getStore: () => Store;
-    setStore: (store: Store) => void;
+    getItem: (key: string) => Promise<string | null>;
+    setItem: (key: string, value: string | null) => Promise<void>;
   };
 
   alert: {
@@ -144,11 +144,6 @@ export interface DeviceSize {
    */
   deviceHeight: number;
 }
-
-/**
- * The type of the store used in local storage
- */
-export type Store = Record<string, string | undefined>;
 
 export type Assets = {
   imageFileNames?: string[];

--- a/packages/replay-core/src/index.ts
+++ b/packages/replay-core/src/index.ts
@@ -10,6 +10,6 @@ export {
   NativeSpriteImplementation,
   NativeSpriteUtils,
 } from "./sprite";
-export { Store, Device, DeviceSize, Assets } from "./device";
+export { Device, DeviceSize, Assets } from "./device";
 export { GameProps, GameSize, GameOrientationSize } from "./core";
 export { mask } from "./mask";

--- a/packages/replay-starter-js/src/__tests__/game.test.js
+++ b/packages/replay-starter-js/src/__tests__/game.test.js
@@ -21,14 +21,14 @@ test("gameplay", async () => {
     jumpToFrame,
     updateInputs,
     getTexture,
-    loadFiles,
+    resolvePromises,
     audio,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs,
     mapInputCoordinates,
   });
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getTexture("icon").props.x).toBe(0);

--- a/packages/replay-starter-ts/src/__tests__/game.test.ts
+++ b/packages/replay-starter-ts/src/__tests__/game.test.ts
@@ -22,14 +22,14 @@ test("gameplay", async () => {
     jumpToFrame,
     updateInputs,
     getTexture,
-    loadFiles,
+    resolvePromises,
     audio,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs,
     mapInputCoordinates,
   });
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getTexture("icon").props.x).toBe(0);

--- a/packages/replay-swift/Replay/Sources/Replay/ReplayStorageProvider.swift
+++ b/packages/replay-swift/Replay/Sources/Replay/ReplayStorageProvider.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+class ReplayStorageProvider {
+    static func getItem(key: String) -> String? {
+        let defaults = UserDefaults.standard
+        
+        return defaults.string(forKey: key)
+    }
+    
+    static func removeItem(key: String) {
+        let defaults = UserDefaults.standard
+        
+        defaults.removeObject(forKey: key)
+    }
+    
+    static func setItem(key: String, value: String) {
+        let defaults = UserDefaults.standard
+        
+        defaults.set(value, forKey: key)
+    }
+    
+    static func handleInternalMessage(message: String, webView: ReplayWebView, internalMessageKey: String) {
+        let getItemKey = "GetItem-"
+        let removeItemKey = "RemoveItem-"
+        let setItemKey = "SetItem-"
+        let setItemKeyValueSeparator = "_____end_of_key______"
+        
+        switch message {
+        case let x where x.starts(with: getItemKey):
+            let key = String(x.dropFirst(getItemKey.count))
+            let value = ReplayStorageProvider.getItem(key: key)
+            
+            let messageId = "\(internalMessageKey)\(getItemKey)\(key)"
+            
+            if let jsString = value {
+                webView.jsBridge(messageId: messageId, jsArg: "`\(jsString)`")
+            } else {
+                webView.jsBridge(messageId: messageId, jsArg: "null")
+            }
+            
+        case let x where x.starts(with: removeItemKey):
+            let key = String(x.dropFirst(removeItemKey.count))
+            
+            ReplayStorageProvider.removeItem(key: key)
+            
+            let messageId = "\(internalMessageKey)\(removeItemKey)\(key)"
+            
+            webView.jsBridge(messageId: messageId, jsArg: "")
+            
+        case let x where x.starts(with: setItemKey):
+            let keyValue = String(x.dropFirst(setItemKey.count))
+                .components(separatedBy: setItemKeyValueSeparator)
+            let key = keyValue[0]
+            let value = keyValue[1]
+            
+            ReplayStorageProvider.setItem(key: key, value: value)
+            
+            let messageId = "\(internalMessageKey)\(setItemKey)\(key)"
+            
+            webView.jsBridge(messageId: messageId, jsArg: "")
+            
+        default:
+            break
+        }
+    }
+}

--- a/packages/replay-swift/Replay/Tests/ReplayTests/ReplayTests.swift
+++ b/packages/replay-swift/Replay/Tests/ReplayTests/ReplayTests.swift
@@ -69,5 +69,10 @@ final class ReplayTests: XCTestCase {
         
         // JS / Swift Bridge
         XCTAssertTrue(logs.contains("Bridge response: Hi!"))
+        
+        // Storage
+        XCTAssertTrue(logs.contains("item1 set: hi"))
+        XCTAssertTrue(logs.contains("item1 removed: null"))
+        XCTAssertTrue(logs.contains("item2: null"))
     }
 }

--- a/packages/replay-swift/src/renderCanvas.ts
+++ b/packages/replay-swift/src/renderCanvas.ts
@@ -1,7 +1,7 @@
 import { GameProps } from "@replay/core";
 import { CustomSprite } from "@replay/core/dist/sprite";
 import { renderCanvas, RenderCanvasOptions } from "@replay/web";
-import { iOSInputs } from "./index";
+import { iOSInputs, swiftBridge } from "./index";
 
 declare const game: {
   Game: (props: GameProps) => CustomSprite<GameProps, unknown, iOSInputs>;
@@ -14,5 +14,27 @@ console.log = (message: string) => {
 };
 
 export function run() {
-  renderCanvas(game.Game(game.gameProps), game.options);
+  renderCanvas(game.Game(game.gameProps), game.options, {
+    storage: {
+      getItem(key) {
+        return swiftBridge<string | null>({
+          id: `__internalReplayGetItem-${key}`,
+          message: `__internalReplayGetItem-${key}`,
+        });
+      },
+      setItem(key, value) {
+        if (value === null) {
+          return swiftBridge<void>({
+            id: `__internalReplayRemoveItem-${key}`,
+            message: `__internalReplayRemoveItem-${key}`,
+          });
+        }
+        return swiftBridge<void>({
+          id: `__internalReplaySetItem-${key}`,
+          // We assume user's keys won't contain this separator
+          message: `__internalReplaySetItem-${key}_____end_of_key______${value}`,
+        });
+      },
+    },
+  });
 }

--- a/packages/replay-swift/test-game/src/index.ts
+++ b/packages/replay-swift/test-game/src/index.ts
@@ -21,6 +21,7 @@ export const gameProps: GameProps = {
 export const Game = makeSprite<GameProps, undefined, iOSInputs>({
   render() {
     return [
+      StorageSprite({ id: "storage" }),
       BridgeSprite({ id: "bridge" }),
       MyNativeSprite({ id: "native" }),
       t.text({
@@ -73,6 +74,32 @@ const MyNativeSpriteWebView: NativeSpriteImplementation<
 export const nativeSpriteMap = {
   MyNativeSprite: MyNativeSpriteWebView,
 };
+
+// -- Storage
+
+const StorageSprite = makeSprite<{}>({
+  init({ device }) {
+    device.storage
+      .setItem("item1", "hi")
+      .then(() => device.storage.getItem("item1"))
+      .then((item1) => {
+        device.log(`item1 set: ${item1}`);
+      })
+      .then(() => device.storage.setItem("item1", null))
+      .then(() => device.storage.getItem("item1"))
+      .then((item1) => {
+        device.log(`item1 removed: ${item1}`);
+      });
+
+    device.storage.getItem("item2").then((item2) => {
+      device.log(`item2: ${item2}`);
+    });
+    return undefined;
+  },
+  render() {
+    return [];
+  },
+});
 
 // -- Swift / JS Bridge
 

--- a/packages/replay-web/src/device.ts
+++ b/packages/replay-web/src/device.ts
@@ -1,4 +1,4 @@
-import { Device, Store } from "@replay/core";
+import { Device } from "@replay/core";
 import { AssetMap } from "@replay/core/dist/device";
 
 /**
@@ -158,24 +158,15 @@ export function getNetwork(): Device<{}>["network"] {
 
 export function getStorage(): Device<{}>["storage"] {
   return {
-    getStore: () => {
-      const store: Store = {};
-      for (let i = 0; i < localStorage.length; i++) {
-        const key = localStorage.key(i);
-        if (key) {
-          store[key] = localStorage.getItem(key) ?? undefined;
-        }
-      }
-      return store;
+    getItem: async (key) => {
+      return localStorage.getItem(key);
     },
-    setStore: (store) => {
-      Object.entries(store).forEach(([field, value]) => {
-        if (value === undefined) {
-          localStorage.removeItem(field);
-        } else {
-          localStorage.setItem(field, value);
-        }
-      });
+    setItem: async (key, value) => {
+      if (value === null) {
+        localStorage.removeItem(key);
+        return;
+      }
+      localStorage.setItem(key, value);
     },
   };
 }

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -73,13 +73,22 @@ export type RenderCanvasOptions = {
   windowSize?: { width: number; height: number };
 };
 
+type PlatformOptions = {
+  storage: Device<{}>["storage"];
+};
+
 /**
  * Render your Replay game to the web canvas. Call this at your game's entry
  * file.
  */
 export function renderCanvas<S>(
   gameSprite: CustomSprite<GameProps, S, Inputs>,
-  options?: RenderCanvasOptions
+  options?: RenderCanvasOptions,
+  /**
+   * Used by platforms (like iOS) rendering in web views. You can ignore this
+   * parameter for building games.
+   */
+  platformOptions?: PlatformOptions
 ) {
   const {
     dimensions = "game-coords",
@@ -386,7 +395,8 @@ export function renderCanvas<S>(
         dimensions,
         gameSprite.props.size
       ),
-      assetUtils
+      assetUtils,
+      platformOptions?.storage || getStorage()
     ),
   };
 
@@ -488,7 +498,8 @@ export function renderCanvas<S>(
 function deviceCreator(
   audioContext: AudioContext,
   defaultSize: DeviceSize,
-  assetUtils: AssetUtils<AudioData, ImageFileData>
+  assetUtils: AssetUtils<AudioData, ImageFileData>,
+  storage: Device<{}>["storage"]
 ): ReplayPlatform<Inputs>["getGetDevice"] {
   // called once
   const initDevice: Omit<Device<Inputs>, "inputs" | "size" | "now"> = {
@@ -499,7 +510,7 @@ function deviceCreator(
     audio: getAudio(audioContext, assetUtils.audioElements),
     assetUtils: assetUtils as AssetUtils<unknown, unknown>,
     network: getNetwork(),
-    storage: getStorage(),
+    storage,
     alert: {
       ok: (message, onResponse) => {
         alert(message);

--- a/website/docs/device.md
+++ b/website/docs/device.md
@@ -186,26 +186,26 @@ network.post("/api/score", { score: 5 }, (data) => {
 
 Platform-independent way of storing save data to the local device.
 
-#### `getStore`
+#### `getItem(key)`
 
-Returns the current store: an object of keys and values of type string.
+Retrieve a saved value by its `string` key. Returns a `string` or `null`.
 
 ```js
-const { highScore } = storage.getStore();
+const playerName = storage.getItem("playerName");
 ```
 
-#### `setStore`
+#### `setItem(key, value)`
 
-Add or remove fields in the store. New fields are merged into the existing store:
+Set or remove a value in storage.
 
 ```js
-storage.setStore({ highScore: 5 });
+storage.setItem("playerName", "Replay");
 ```
 
-Setting `undefined` will remove a field from storage:
+Setting `null` will remove a field from storage:
 
 ```js
-storage.setStore({ highScore: undefined });
+storage.setItem("playerName", null);
 ```
 
 ### `alert`

--- a/website/docs/game-size.md
+++ b/website/docs/game-size.md
@@ -101,7 +101,7 @@ Here's how you could render a game's score at the top of the screen on all devic
     return [
       t.text({
         text: `Score: ${props.score}`,
-        font: { name: "Courier", size: 16 },
+        font: { family: "Courier", size: 16 },
         color: "red",
         y: topY,
         anchorY: 8,

--- a/website/docs/test.md
+++ b/website/docs/test.md
@@ -62,12 +62,12 @@ Note that this will run at almost synchronous speed, but doesn't block the event
 await jumpToFrame(() => props.x > 10);
 ```
 
-### `loadFiles()`
+### `resolvePromises()`
 
-An async function that loads all files specified by Sprites using [`preloadFiles`](sprites.md#init).
+An async function that can be used to flush Promises - such as loading all files specified by Sprites using [`preloadFiles`](sprites.md#init) and accessing storage.
 
 ```js
-await loadFiles();
+await resolvePromises();
 ```
 
 ### `setRandomNumbers(array)`
@@ -217,12 +217,12 @@ test("Can shoot bullet", async () => {
     updateInputs,
     getTexture,
     textureExists,
-    loadFiles,
+    resolvePromises,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs,
   });
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(textureExists("bullet")).toBe(false);
@@ -271,12 +271,12 @@ test("Can shoot bullet", async () => {
     updateInputs,
     getTexture,
     textureExists,
-    loadFiles,
+    resolvePromises,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs,
   });
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(textureExists("bullet")).toBe(false);

--- a/website/docs/tutorial/16.md
+++ b/website/docs/tutorial/16.md
@@ -4,4 +4,4 @@ Let's add a score to count how many pipes the bird managed to fly past.
 
 In the `Level` Sprite we add a `score` field to the state and increment it whenever we pass a pipe. Then we render it in the top-left corner with a `t.text` Texture.
 
-Notice the `align` prop on the text Texture: by default, Sprites have an anchor point in their center, which defines how they're positioned and rotate. Setting `align: "left"` moves the left edge of the text to the Sprite's anchor point, providing a left text align for the score. The `x` position of the Texture is now the left side of it, not the center.
+Notice the `align` field of the `font` prop on the text Texture: by default, Sprites have an anchor point in their center, which defines how they're positioned and rotate. Setting `align: "left"` moves the left edge of the text to the Sprite's anchor point, providing a left text align for the score. The `x` position of the Texture is now the left side of it, not the center.

--- a/website/docs/tutorial/17.md
+++ b/website/docs/tutorial/17.md
@@ -2,9 +2,9 @@
 
 It would be nice to save a high score between plays! Replay provides a simple way to save things to local storage on the device.
 
-In our top-level `Game` Sprite we add a `highScore` state field. In `init` we want to set this value to be what's saved in local storage. `device.storage.getStore()` accesses the current store, which is an object of string keys and values. If there's no `highScore` value in the store, then we set a default of `0`.
+In our top-level `Game` Sprite we add a `highScore` state field. In `init` we want to set this value to be what's saved in local storage. `device.storage.getItem(key)` returns a Promise containing the string value we saved under the key `"highScore"`. When the Promise returns we update our high score field. If there's no `highScore` value saved from a previous game, then we set a default of `0`.
 
-In the `gameOver` callback we'll have the `Level` Sprite pass in the current score. If it's higher than our `highScore` state value, we replace the value in the `Game` Sprite's state and the store. Calling `device.storage.setStore({ key, value })` will merge the key and value into the existing store and save it.
+In the `gameOver` callback we'll have the `Level` Sprite pass in the current score. If it's higher than our `highScore` state value, we replace the value in the `Game` Sprite's state and the store. Calling `device.storage.setItem(key, value)` will save the value on the device under the key passed in.
 
 In the `Level` Sprite we need to pass the score into the `gameOver` callback.
 

--- a/website/docs/tutorial/18.md
+++ b/website/docs/tutorial/18.md
@@ -6,7 +6,7 @@ replay-starter stores its images in the `assets/images` folder, so we can copy o
 
 In our `Bird` Sprite we replace the rectangle with the `t.image` Texture, set to the same width and height.
 
-To use the image it first needs to be loaded. Back in our top-level `Game` Sprite we can load it when the game launches using `preloadFiles` and by specifying the image file names to load.
+To use the image it first needs to be loaded. Back in our top-level `Game` Sprite we can load it when the game launches using `preloadFiles` and by specifying the image file names to load. Putting it in `Promise.all` allows us to load the assets at the same time saved data is being loaded.
 
 We don't want to render the image until the loading is finished, so we add a `view` state called `"loading"` before we enter the menu. In the `render` function we can then return a text Texture of `"Loading..."` before the game starts.
 

--- a/website/docs/tutorial/20.md
+++ b/website/docs/tutorial/20.md
@@ -6,7 +6,7 @@ Using [Jest](https://jestjs.io/) we can write an initial test to confirm we can 
 
 In `__tests__/game.test` replace what's there with the code on the right. We pass our `Game` Sprite (and `gameProps`) into the `testSprite` function, which returns some more useful functions for inspecting our game. Since the test platform doesn't know if we want to run on web or iOS, we need to supply the inputs we'd expect on those platforms through `initInputs`.
 
-Then we have to wait for our loading screen to pass by calling `await loadFiles()`.
+Then we have to wait for our loading screen to pass by calling `await resolvePromises()`.
 
 Below that `getByText(mainMenuText)` searches all `t.text` Textures that match the string passed in. This confirms that our main menu is visible on the initial render.
 

--- a/website/docs/tutorial/4.md
+++ b/website/docs/tutorial/4.md
@@ -4,4 +4,4 @@ Below the `Game` are the `gameProps`. We don't apply them now, but when we run t
 
 You can see an example of this in the `web/index` file, where we call the `renderCanvas` function from the `@replay/web` package to render our game in the browser.
 
-`gameProps` requires an `id` for the `Game` Sprite and the `size` of our game, which we'll discuss next. We also add an _optional_ `defaultFont` `prop` to set the default font size and keep a consistent font name for any text we render later on.
+`gameProps` requires an `id` for the `Game` Sprite and the `size` of our game, which we'll discuss next. We also add an _optional_ `defaultFont` `prop` to set the default font size and keep a consistent font family for any text we render later on.

--- a/website/src/pages/tutorial/16.js
+++ b/website/src/pages/tutorial/16.js
@@ -22,14 +22,14 @@ function Tutorial() {
         {
           file: "level.ts",
           code: levelTs,
-          highlight: [19, 28, 39, 68, 77, "102-108"],
+          highlight: [19, 28, 39, 68, 77, "102-110"],
         },
       ]}
       codesJs={[
         {
           file: "level.js",
           code: levelJs,
-          highlight: [14, 25, 54, 63, "88-94"],
+          highlight: [14, 25, 54, 63, "88-96"],
         },
       ]}
       Game={Game}

--- a/website/src/pages/tutorial/17.js
+++ b/website/src/pages/tutorial/17.js
@@ -26,7 +26,7 @@ function Tutorial() {
         {
           file: "index.ts",
           code: indexTs,
-          highlight: [8, 12, 13, 17, 21, 28, "30-34", 38, 46],
+          highlight: [8, "12-27", 29, 36, "38-42", 46, 54],
         },
         {
           file: "level.ts",
@@ -43,7 +43,7 @@ function Tutorial() {
         {
           file: "index.js",
           code: indexJs,
-          highlight: [6, 7, 11, 15, 22, "24-28", 32, 40],
+          highlight: ["6-21", 23, 30, "32-36", 40, 48],
         },
         {
           file: "level.js",

--- a/website/src/pages/tutorial/18.js
+++ b/website/src/pages/tutorial/18.js
@@ -29,7 +29,7 @@ function Tutorial() {
         {
           file: "index.ts",
           code: indexTs,
-          highlight: [1, 6, "12-19", 23, "30-37"],
+          highlight: [1, 6, "13-29", "36-43"],
         },
       ]}
       codesJs={[
@@ -41,7 +41,7 @@ function Tutorial() {
         {
           file: "index.js",
           code: indexJs,
-          highlight: [1, "6-13", 17, "24-31"],
+          highlight: [1, "7-23", "30-37"],
         },
       ]}
       Game={Game}

--- a/website/src/pages/tutorial/19.js
+++ b/website/src/pages/tutorial/19.js
@@ -26,7 +26,7 @@ function Tutorial() {
           code: levelTs,
           highlight: [59],
         },
-        { file: "index.ts", code: indexTs, highlight: [15] },
+        { file: "index.ts", code: indexTs, highlight: [17] },
       ]}
       codesJs={[
         {
@@ -34,7 +34,7 @@ function Tutorial() {
           code: levelJs,
           highlight: [45],
         },
-        { file: "index.js", code: indexJs, highlight: [9] },
+        { file: "index.js", code: indexJs, highlight: [11] },
       ]}
       Game={Game}
       gameProps={gameProps}

--- a/website/src/tutorial/17/js/index.js
+++ b/website/src/tutorial/17/js/index.js
@@ -3,12 +3,20 @@ import { Level } from "./level";
 import { Menu } from "./menu";
 
 export const Game = makeSprite({
-  init({ device }) {
-    const store = device.storage.getStore();
+  init({ device, updateState }) {
+    device.storage.getItem("highScore").then((highScore) => {
+      updateState((state) => {
+        return {
+          ...state,
+          highScore: Number(highScore || "0"),
+        };
+      });
+    });
+
     return {
       view: "menu",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -24,7 +32,7 @@ export const Game = makeSprite({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/17/ts/index.ts
+++ b/website/src/tutorial/17/ts/index.ts
@@ -9,12 +9,20 @@ type GameState = {
 };
 
 export const Game = makeSprite<GameProps, GameState>({
-  init({ device }) {
-    const store = device.storage.getStore();
+  init({ device, updateState }) {
+    device.storage.getItem("highScore").then((highScore) => {
+      updateState((state) => {
+        return {
+          ...state,
+          highScore: Number(highScore || "0"),
+        };
+      });
+    });
+
     return {
       view: "menu",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -30,7 +38,7 @@ export const Game = makeSprite<GameProps, GameState>({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/18/js/index.js
+++ b/website/src/tutorial/18/js/index.js
@@ -4,19 +4,25 @@ import { Menu } from "./menu";
 
 export const Game = makeSprite({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["/img/bird.png"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["/img/bird.png"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -41,7 +47,7 @@ export const Game = makeSprite({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/18/ts/index.ts
+++ b/website/src/tutorial/18/ts/index.ts
@@ -10,19 +10,25 @@ type GameState = {
 
 export const Game = makeSprite<GameProps, GameState>({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["bird.png"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["bird.png"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -47,7 +53,7 @@ export const Game = makeSprite<GameProps, GameState>({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/19/js/index.js
+++ b/website/src/tutorial/19/js/index.js
@@ -4,20 +4,26 @@ import { Menu } from "./menu";
 
 export const Game = makeSprite({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["/img/bird.png"],
-      audioFileNames: ["/audio/boop.wav"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["/img/bird.png"],
+        audioFileNames: ["/audio/boop.wav"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -42,7 +48,7 @@ export const Game = makeSprite({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/19/ts/index.ts
+++ b/website/src/tutorial/19/ts/index.ts
@@ -10,20 +10,26 @@ type GameState = {
 
 export const Game = makeSprite<GameProps, GameState>({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["bird.png"],
-      audioFileNames: ["boop.wav"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["bird.png"],
+        audioFileNames: ["boop.wav"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -48,7 +54,7 @@ export const Game = makeSprite<GameProps, GameState>({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/20/js/__tests__/game.test.js
+++ b/website/src/tutorial/20/js/__tests__/game.test.js
@@ -16,7 +16,7 @@ test("Can start game", async () => {
   };
   const mainMenuText = "Start";
 
-  const { nextFrame, updateInputs, getByText, loadFiles } = testSprite(
+  const { nextFrame, updateInputs, getByText, resolvePromises } = testSprite(
     Game(gameProps),
     gameProps,
     {
@@ -24,7 +24,7 @@ test("Can start game", async () => {
     }
   );
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getByText(mainMenuText).length).toBe(1);

--- a/website/src/tutorial/20/js/index.js
+++ b/website/src/tutorial/20/js/index.js
@@ -4,20 +4,26 @@ import { Menu } from "./menu";
 
 export const Game = makeSprite({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["/img/bird.png"],
-      audioFileNames: ["/audio/boop.wav"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["/img/bird.png"],
+        audioFileNames: ["/audio/boop.wav"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -42,7 +48,7 @@ export const Game = makeSprite({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/20/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/20/ts/__tests__/game.test.ts
@@ -18,7 +18,7 @@ test("Can start game", async () => {
   };
   const mainMenuText = "Start";
 
-  const { nextFrame, updateInputs, getByText, loadFiles } = testSprite(
+  const { nextFrame, updateInputs, getByText, resolvePromises } = testSprite(
     Game(gameProps),
     gameProps,
     {
@@ -26,7 +26,7 @@ test("Can start game", async () => {
     }
   );
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getByText(mainMenuText).length).toBe(1);

--- a/website/src/tutorial/20/ts/index.ts
+++ b/website/src/tutorial/20/ts/index.ts
@@ -10,20 +10,26 @@ type GameState = {
 
 export const Game = makeSprite<GameProps, GameState>({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["bird.png"],
-      audioFileNames: ["boop.wav"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["bird.png"],
+        audioFileNames: ["boop.wav"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -48,7 +54,7 @@ export const Game = makeSprite<GameProps, GameState>({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/21/js/__tests__/game.test.js
+++ b/website/src/tutorial/21/js/__tests__/game.test.js
@@ -25,14 +25,14 @@ test("Can reach a score of 2", async () => {
     getTexture,
     jumpToFrame,
     audio,
-    loadFiles,
+    resolvePromises,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs,
     // First two pipes will have gap in middle, third pipe lower down
     initRandom: [0.5, 0.5, 0],
   });
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getByText(mainMenuText).length).toBe(1);

--- a/website/src/tutorial/21/js/index.js
+++ b/website/src/tutorial/21/js/index.js
@@ -4,20 +4,26 @@ import { Menu } from "./menu";
 
 export const Game = makeSprite({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["/img/bird.png"],
-      audioFileNames: ["/audio/boop.wav"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["/img/bird.png"],
+        audioFileNames: ["/audio/boop.wav"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -42,7 +48,7 @@ export const Game = makeSprite({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/21/ts/__tests__/game.test.ts
+++ b/website/src/tutorial/21/ts/__tests__/game.test.ts
@@ -27,14 +27,14 @@ test("Can reach a score of 2", async () => {
     getTexture,
     jumpToFrame,
     audio,
-    loadFiles,
+    resolvePromises,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs,
     // First two pipes will have gap in middle, third pipe lower down
     initRandom: [0.5, 0.5, 0],
   });
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getByText(mainMenuText).length).toBe(1);

--- a/website/src/tutorial/21/ts/index.ts
+++ b/website/src/tutorial/21/ts/index.ts
@@ -10,20 +10,26 @@ type GameState = {
 
 export const Game = makeSprite<GameProps, GameState>({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["bird.png"],
-      audioFileNames: ["boop.wav"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["bird.png"],
+        audioFileNames: ["boop.wav"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -48,7 +54,7 @@ export const Game = makeSprite<GameProps, GameState>({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/final/js/src/__tests__/game.test.js
+++ b/website/src/tutorial/final/js/src/__tests__/game.test.js
@@ -25,14 +25,14 @@ test("Can reach a score of 2", async () => {
     getTexture,
     jumpToFrame,
     audio,
-    loadFiles,
+    resolvePromises,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs,
     // First two pipes will have gap in middle, third pipe lower down
     initRandom: [0.5, 0.5, 0],
   });
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getByText(mainMenuText).length).toBe(1);

--- a/website/src/tutorial/final/js/src/index.js
+++ b/website/src/tutorial/final/js/src/index.js
@@ -4,20 +4,26 @@ import { Menu } from "./menu";
 
 export const Game = makeSprite({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["/img/bird.png"],
-      audioFileNames: ["/audio/boop.wav"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["/img/bird.png"],
+        audioFileNames: ["/audio/boop.wav"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -42,7 +48,7 @@ export const Game = makeSprite({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,

--- a/website/src/tutorial/final/ts/src/__tests__/game.test.ts
+++ b/website/src/tutorial/final/ts/src/__tests__/game.test.ts
@@ -27,14 +27,14 @@ test("Can reach a score of 2", async () => {
     getTexture,
     jumpToFrame,
     audio,
-    loadFiles,
+    resolvePromises,
   } = testSprite(Game(gameProps), gameProps, {
     initInputs,
     // First two pipes will have gap in middle, third pipe lower down
     initRandom: [0.5, 0.5, 0],
   });
 
-  await loadFiles();
+  await resolvePromises();
   nextFrame();
 
   expect(getByText(mainMenuText).length).toBe(1);

--- a/website/src/tutorial/final/ts/src/index.ts
+++ b/website/src/tutorial/final/ts/src/index.ts
@@ -10,20 +10,26 @@ type GameState = {
 
 export const Game = makeSprite<GameProps, GameState>({
   init({ device, preloadFiles, updateState }) {
-    preloadFiles({
-      imageFileNames: ["bird.png"],
-      audioFileNames: ["boop.wav"],
-    }).then(() => {
+    Promise.all([
+      device.storage.getItem("highScore"),
+      preloadFiles({
+        imageFileNames: ["bird.png"],
+        audioFileNames: ["boop.wav"],
+      }),
+    ]).then(([highScore]) => {
       updateState((state) => {
-        return { ...state, view: "menu" };
+        return {
+          ...state,
+          view: "menu",
+          highScore: Number(highScore || "0"),
+        };
       });
     });
 
-    const store = device.storage.getStore();
     return {
       view: "loading",
       attempt: 0,
-      highScore: Number(store.highScore || "0"),
+      highScore: 0,
     };
   },
 
@@ -48,7 +54,7 @@ export const Game = makeSprite<GameProps, GameState>({
             let { highScore } = prevState;
             if (score > highScore) {
               highScore = score;
-              device.storage.setStore({ highScore: String(highScore) });
+              device.storage.setItem("highScore", String(highScore));
             }
             return {
               ...prevState,


### PR DESCRIPTION
**Breaking changes**
- Replace `device.storage` `getStore()` and `setStore(val)` with async `getItem(key)` and `setItem(key, val)`.
- Rename `loadFiles` to `resolvePromises` in replay-test.

Being async means we can use native storage - e.g. on iOS, `localStorage` has a maximum size of 5 MB. iOS now uses `UserDefaults` which has no limit. Storing by key is closer to how it's done on the platform level and so should be more performant.