### PR TITLE
Use Documents files for iOS storage

### DIFF
--- a/packages/replay-swift/Replay/Tests/ReplayTests/ReplayTests.swift
+++ b/packages/replay-swift/Replay/Tests/ReplayTests/ReplayTests.swift
@@ -19,7 +19,24 @@ final class ReplayTests: XCTestCase {
         
         var webView: ReplayWebView!
         
-        let onLogCallback = { logs.append($0) }
+        let storageExpectation1 = self.expectation(description: "item1 set")
+        let storageExpectation2 = self.expectation(description: "item1 removed")
+        let storageExpectation3 = self.expectation(description: "item2 not set")
+        
+        let onLogCallback = { (value: String) in
+            logs.append(value)
+            
+            // Check async callbacks
+            if value == "item1 set: hi" {
+                storageExpectation1.fulfill()
+            }
+            if value == "item1 removed: null" {
+                storageExpectation2.fulfill()
+            }
+            if value == "item2: null" {
+                storageExpectation3.fulfill()
+            }
+        }
         
         webView = ReplayWebViewManager(
             customGameJsString: gameJsString,
@@ -71,9 +88,7 @@ final class ReplayTests: XCTestCase {
         XCTAssertTrue(logs.contains("Bridge response: Hi!"))
         
         // Storage
-        XCTAssertTrue(logs.contains("item1 set: hi"))
-        XCTAssertTrue(logs.contains("item1 removed: null"))
-        XCTAssertTrue(logs.contains("item2: null"))
+        wait(for: [storageExpectation1, storageExpectation2, storageExpectation3], timeout: 5)
         
         // Clipboard
         XCTAssertTrue(logs.contains("Copied!"))

--- a/packages/replay-swift/src/renderCanvas.ts
+++ b/packages/replay-swift/src/renderCanvas.ts
@@ -38,6 +38,7 @@ export function run() {
             if (typeof error === "string") {
               throw Error(error);
             }
+            return;
           }
           const error = await swiftBridge<void | string>({
             id: `__internalReplayStorageSetItem-${key}`,

--- a/packages/replay-swift/src/renderCanvas.ts
+++ b/packages/replay-swift/src/renderCanvas.ts
@@ -17,24 +17,36 @@ export function run() {
   renderCanvas(game.Game(game.gameProps), game.options, {
     device: {
       storage: {
-        getItem(key) {
-          return swiftBridge<string | null>({
+        getItem: async (key) => {
+          const result = await swiftBridge<
+            { value: string | null } | { error: string }
+          >({
             id: `__internalReplayStorageGetItem-${key}`,
             message: `__internalReplayStorageGetItem-${key}`,
           });
+          if ("error" in result) {
+            throw Error(result.error);
+          }
+          return result.value;
         },
-        setItem(key, value) {
+        setItem: async (key, value) => {
           if (value === null) {
-            return swiftBridge<void>({
+            const error = await swiftBridge<void | string>({
               id: `__internalReplayStorageRemoveItem-${key}`,
               message: `__internalReplayStorageRemoveItem-${key}`,
             });
+            if (typeof error === "string") {
+              throw Error(error);
+            }
           }
-          return swiftBridge<void>({
+          const error = await swiftBridge<void | string>({
             id: `__internalReplayStorageSetItem-${key}`,
             // We assume user's keys won't contain this separator
             message: `__internalReplayStorageSetItem-${key}_____end_of_key______${value}`,
           });
+          if (typeof error === "string") {
+            throw Error(error);
+          }
         },
       },
       clipboard: {


### PR DESCRIPTION
Previously we were using `UserDefaults` on iOS to store locally, but this has a [4 MB limit on recent iOS versions](https://developer.apple.com/forums/thread/121527).

This PR uses the app's Documents folder to persist files instead and shouldn't have any limits.