### PR TITLE
Core Performance

### DIFF
--- a/dev-game/package.json
+++ b/dev-game/package.json
@@ -5,7 +5,7 @@
   "description": "An example game for developing Replay",
   "main": "src/index.ts",
   "scripts": {
-    "start": "webpack-dev-server --config webpack.web.js --open",
+    "start": "webpack serve -d eval-cheap-module-source-map --config webpack.web.js --mode development --open",
     "build": "npm run build-web && npm run build-swift",
     "build-web": "webpack --config webpack.web.js",
     "build-swift": "webpack --config webpack.swift.js",

--- a/dev-game/src/Clickable.ts
+++ b/dev-game/src/Clickable.ts
@@ -16,9 +16,10 @@ export const Clickable = makeSprite<
 >({
   render({
     props: { sprites, width, height, onPress, onPressOutside },
-    device,
+    getInputs,
   }) {
-    const { x, y, justReleased, pressed } = device.inputs.pointer;
+    const inputs = getInputs();
+    const { x, y, justReleased, pressed } = inputs.pointer;
 
     const isOnButton =
       x <= width / 2 && x >= -width / 2 && y <= height / 2 && y >= -height / 2;

--- a/dev-game/src/PlayStage.ts
+++ b/dev-game/src/PlayStage.ts
@@ -80,11 +80,12 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ state, device, props: { bulletSpeed, gameOver } }) {
+  loop({ state, device, getInputs, props: { bulletSpeed, gameOver } }) {
     if (state.paused || state.loading) return state;
 
+    const inputs = getInputs();
+
     const {
-      inputs,
       size: { width, height, heightMargin, widthMargin },
     } = device;
     const fullWidth = width + widthMargin * 2;
@@ -146,8 +147,8 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
       bullets,
       enemies,
       pointer: {
-        x: device.inputs.pointer.x,
-        y: device.inputs.pointer.y,
+        x: inputs.pointer.x,
+        y: inputs.pointer.y,
       },
       score,
       spawnEnemyTimerId: state.spawnEnemyTimerId,

--- a/dev-game/src/PlayStage.ts
+++ b/dev-game/src/PlayStage.ts
@@ -44,7 +44,7 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
       imageFileNames: ["enemy.png"],
       audioFileNames: ["shoot.wav"],
     }).then(() => {
-      const spawnEnemy = () => {
+      function spawnEnemy() {
         device.log("Spawn");
         const timerId = device.timer.start(() => {
           const newId = spawnEnemy();
@@ -59,7 +59,7 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
           }));
         }, device.random() * 2000 + 1000);
         return timerId;
-      };
+      }
       const timerId = spawnEnemy();
       updateState((s) => ({
         ...s,
@@ -100,8 +100,10 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
 
     // bullets
     bullets = bullets
-      .map((b) => ({ ...b, distance: b.distance + bulletSpeed }))
-      .filter((b) => {
+      .map(function mapBullet(b) {
+        return { ...b, distance: b.distance + bulletSpeed };
+      })
+      .filter(function filterBullet(b) {
         const x = bulletX(b);
         const y = bulletY(b, fullHeight / 2);
         return (
@@ -121,8 +123,10 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
 
     // enemies
     enemies = enemies
-      .map((e) => ({ ...e, y: e.y - e.speed }))
-      .filter((e) => {
+      .map(function mapEnemy(e) {
+        return { ...e, y: e.y - e.speed };
+      })
+      .filter(function filterEnemy(e) {
         let isNotHit = true;
         bullets.forEach((b) => {
           const x = bulletX(b);
@@ -134,7 +138,7 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
         });
         return isNotHit;
       });
-    enemies.forEach((e) => {
+    enemies.forEach(function forEachEnemy(e) {
       if (e.y < -fullHeight / 2) {
         device.timer.cancel(state.spawnEnemyTimerId);
         gameOver(score);
@@ -171,26 +175,26 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
     }
     const fullHeight = height + heightMargin * 2;
     const fullWidth = width + widthMargin * 2;
-    const bullets = state.bullets.map((b, i) =>
-      t.circle({
+    const bullets = state.bullets.map(function bulletsMapTexture(b, i) {
+      return t.circle({
         x: bulletX(b, extrapolateFactor * bulletSpeed),
         y: bulletY(b, fullHeight / 2, extrapolateFactor * bulletSpeed),
         testId: `bullet${i + 1}`,
         radius: 2,
         color: "#0095DD",
         opacity: 0.9,
-      })
-    );
-    const enemies = state.enemies.map((e, i) =>
-      t.image({
+      });
+    });
+    const enemies = state.enemies.map(function enemiesMapTexture(e, i) {
+      return t.image({
         x: e.x,
         y: e.y,
         testId: `enemy${i + 1}`,
         fileName: "enemy.png",
         width: 20,
         height: 20,
-      })
-    );
+      });
+    });
     return [
       // t.rectangle({
       //   testId: "background",
@@ -269,19 +273,21 @@ export const PlayStage = makeSprite<Props, State, WebInputs | iOSInputs>({
         : null,
       Clickable({
         id: "PauseButton",
-        sprites: () => [
-          t.rectangle({
-            width: 100,
-            height: 20,
-            color: "black",
-            opacity: 0.2,
-          }),
-          t.text({
-            text: state.paused ? "Resume" : "Pause",
-            color: "purple",
-          }),
-        ],
-        onPress: () => {
+        sprites: function clickableSprites() {
+          return [
+            t.rectangle({
+              width: 100,
+              height: 20,
+              color: "black",
+              opacity: 0.2,
+            }),
+            t.text({
+              text: state.paused ? "Resume" : "Pause",
+              color: "purple",
+            }),
+          ];
+        },
+        onPress: function clickableOnPress() {
           updateState((s) => {
             if (s.paused) {
               timer.resume(s.spawnEnemyTimerId);

--- a/dev-game/src/PosLogger.ts
+++ b/dev-game/src/PosLogger.ts
@@ -3,11 +3,11 @@ import { WebInputs } from "../../packages/replay-web/src";
 import { iOSInputs } from "../../packages/replay-swift/src";
 
 export const PosLogger = makeSprite<{}, undefined, WebInputs | iOSInputs>({
-  render({ device }) {
-    if (device.inputs.pointer.justPressed) {
-      device.log(
-        `x: ${device.inputs.pointer.x}, y: ${device.inputs.pointer.y}`
-      );
+  render({ device, getInputs }) {
+    const inputs = getInputs();
+
+    if (inputs.pointer.justPressed) {
+      device.log(`x: ${inputs.pointer.x}, y: ${inputs.pointer.y}`);
     }
     return [];
   },

--- a/dev-game/src/index.ts
+++ b/dev-game/src/index.ts
@@ -104,8 +104,8 @@ export const Game = makeSprite<GameProps, State, WebInputs | iOSInputs>({
     return { ...initState, highScore: 0 };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, device, getInputs }) {
+    const inputs = getInputs();
     const { stage } = state;
 
     // stage

--- a/dev-game/src/index.ts
+++ b/dev-game/src/index.ts
@@ -170,7 +170,7 @@ export const Game = makeSprite<GameProps, State, WebInputs | iOSInputs>({
           PlayStage({
             id: "play-stage",
             bulletSpeed: state.bulletSpeed,
-            gameOver: (score) => {
+            gameOver: function gameOver(score) {
               if (score > state.highScore) {
                 device.storage.setItem("highScore", String(score));
               }
@@ -191,13 +191,13 @@ export const Game = makeSprite<GameProps, State, WebInputs | iOSInputs>({
 
 const PureCircleGroup = makePureSprite({
   shouldRerender() {
-    return true;
+    return false;
   },
 
   render() {
-    return Array.from({ length: 2000 }).map((_, index) =>
-      PureCircle({ id: `Circle-${index}` })
-    );
+    return Array.from({ length: 2000 }).map(function mapCircles(_, index) {
+      return PureCircle({ id: `Circle-${index}` });
+    });
   },
 });
 

--- a/packages/replay-core/src/__benchmarks__/replay-core.benchmark.ts
+++ b/packages/replay-core/src/__benchmarks__/replay-core.benchmark.ts
@@ -161,8 +161,8 @@ export function runRemovedSprites(arg: SuiteArg) {
       return { x: 0 };
     },
 
-    loop({ state, device }) {
-      if (device.inputs.clicked) {
+    loop({ state, getInputs }) {
+      if (getInputs().clicked) {
         return state;
       }
       return { ...state, x: state.x + 1 };

--- a/packages/replay-core/src/__benchmarks__/replay-core.benchmark.ts
+++ b/packages/replay-core/src/__benchmarks__/replay-core.benchmark.ts
@@ -103,8 +103,8 @@ export function runInputSprite(arg: SuiteArg) {
     init() {
       return { x: 0 };
     },
-    loop({ state, device }) {
-      if (device.inputs.clicked) {
+    loop({ state, getInputs }) {
+      if (getInputs().clicked) {
         return { ...state, x: state.x + 1 };
       }
       return state;

--- a/packages/replay-core/src/__benchmarks__/utils.ts
+++ b/packages/replay-core/src/__benchmarks__/utils.ts
@@ -58,8 +58,7 @@ function getBenchmarkPlatform() {
     clicked: false,
   };
 
-  const mutableTestDevice: Device<Inputs> = {
-    inputs,
+  const mutableTestDevice: Device = {
     isTouchScreen: false,
     size: {
       width: 300,
@@ -128,15 +127,11 @@ function getBenchmarkPlatform() {
   };
 
   const platform: ReplayPlatform<Inputs> = {
-    getGetDevice: () => {
-      return (getLocalCoords) => {
-        const local = getLocalCoords(inputs);
-        return {
-          ...mutableTestDevice,
-          inputs: { ...inputs, x: local.x, y: local.y },
-        };
-      };
+    getInputs: (globalToLocalCoords) => {
+      const local = globalToLocalCoords(inputs);
+      return { ...inputs, x: local.x, y: local.y };
     },
+    mutDevice: mutableTestDevice,
     render: {
       newFrame: () => null,
       startRenderSprite: () => null,

--- a/packages/replay-core/src/__benchmarks__/utils.ts
+++ b/packages/replay-core/src/__benchmarks__/utils.ts
@@ -20,7 +20,7 @@ export function runGame(
 ) {
   const platform = getBenchmarkPlatform();
 
-  const { getNextFrameTextures } = replayCore(
+  const { runNextFrame } = replayCore(
     platform,
     getNativeSpriteSettings(),
     Game(gameProps)
@@ -32,7 +32,7 @@ export function runGame(
   // Run 1000 frames
   for (let i = 1; i <= 1000; i++) {
     arg.onFrameStart(i);
-    getNextFrameTextures(i * oneFrameMs, resetInputs);
+    runNextFrame(i * oneFrameMs, resetInputs);
     arg.onFrameEnd(i);
   }
 }
@@ -136,6 +136,12 @@ function getBenchmarkPlatform() {
           inputs: { ...inputs, x: local.x, y: local.y },
         };
       };
+    },
+    render: {
+      newFrame: () => null,
+      startRenderSprite: () => null,
+      endRenderSprite: () => null,
+      renderTexture: () => null,
     },
   };
 

--- a/packages/replay-core/src/__tests__/replay-core.test.ts
+++ b/packages/replay-core/src/__tests__/replay-core.test.ts
@@ -29,12 +29,12 @@ import { NativeSpriteUtils } from "../sprite";
 import { TextTexture, CircleTexture } from "../t";
 
 test("can render simple game and runNextFrame", () => {
-  const { platform, mutableTestDevice, textures } = getTestPlatform();
+  const { platform, mutInputs, textures } = getTestPlatform();
   const platformSpy = {
-    getDevice: jest.spyOn(platform, "getGetDevice"),
+    getInputs: jest.spyOn(platform, "getInputs"),
   };
 
-  mutableTestDevice.inputs.buttonPressed.move = true;
+  mutInputs.ref.buttonPressed.move = true;
 
   const { runNextFrame } = replayCore(
     platform,
@@ -48,7 +48,7 @@ test("can render simple game and runNextFrame", () => {
     runNextFrame(time, jest.fn());
   };
 
-  expect(platformSpy.getDevice).toBeCalledTimes(1);
+  expect(platformSpy.getInputs).toBeCalledTimes(0);
   expect(textures).toEqual([
     {
       type: "circle",
@@ -70,7 +70,7 @@ test("can render simple game and runNextFrame", () => {
 
   nextFrame();
 
-  expect(platformSpy.getDevice).toBeCalledTimes(2);
+  expect(platformSpy.getInputs).toBeCalledTimes(1);
   expect(textures[0]).toEqual({
     type: "circle",
     props: {
@@ -88,10 +88,10 @@ test("can render simple game and runNextFrame", () => {
     },
   });
 
-  mutableTestDevice.inputs.buttonPressed.move = true;
+  mutInputs.ref.buttonPressed.move = true;
   nextFrame();
 
-  expect(platformSpy.getDevice).toBeCalledTimes(3);
+  expect(platformSpy.getInputs).toBeCalledTimes(2);
   expect(textures[0]).toEqual({
     type: "circle",
     props: {
@@ -111,12 +111,12 @@ test("can render simple game and runNextFrame", () => {
 });
 
 test("can render simple game with sprites", () => {
-  const { platform, mutableTestDevice, textures } = getTestPlatform();
+  const { platform, mutInputs, textures } = getTestPlatform();
   const platformSpy = {
-    getDevice: jest.spyOn(platform, "getGetDevice"),
+    getInputs: jest.spyOn(platform, "getInputs"),
   };
 
-  mutableTestDevice.inputs.buttonPressed.move = true;
+  mutInputs.ref.buttonPressed.move = true;
 
   const { runNextFrame } = replayCore(
     platform,
@@ -130,7 +130,7 @@ test("can render simple game with sprites", () => {
     runNextFrame(time, jest.fn());
   };
 
-  expect(platformSpy.getDevice).toBeCalledTimes(1);
+  expect(platformSpy.getInputs).toBeCalledTimes(1);
 
   expect(textures[0]).toEqual({
     type: "circle",
@@ -151,7 +151,7 @@ test("can render simple game with sprites", () => {
 
   nextFrame();
 
-  expect(platformSpy.getDevice).toBeCalledTimes(2);
+  expect(platformSpy.getInputs).toBeCalledTimes(2);
 
   expect(textures[0]).toEqual({
     type: "circle",
@@ -170,13 +170,13 @@ test("can render simple game with sprites", () => {
     },
   });
 
-  mutableTestDevice.inputs.buttonPressed.show = false;
+  mutInputs.ref.buttonPressed.show = false;
 
   nextFrame();
 
   expect(textures).toEqual([]);
 
-  mutableTestDevice.inputs.buttonPressed.show = true;
+  mutInputs.ref.buttonPressed.show = true;
 
   nextFrame();
 
@@ -264,7 +264,7 @@ test("Can render simple game with sprites in XL portrait", () => {
 });
 
 test("can log", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
   const { runNextFrame } = replayCore(
@@ -279,14 +279,14 @@ test("can log", () => {
     runNextFrame(time, jest.fn());
   };
 
-  mutableTestDevice.inputs.buttonPressed.log = true;
+  mutInputs.ref.buttonPressed.log = true;
   nextFrame();
 
   expect(logSpy).toBeCalledWith("Log Message");
 });
 
 test("can provide a random number", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const randomSpy = jest.spyOn(mutableTestDevice, "random");
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
@@ -296,7 +296,7 @@ test("can provide a random number", () => {
     FullTestGame(gameProps)
   );
 
-  mutableTestDevice.inputs.buttonPressed.setRandom = true;
+  mutInputs.ref.buttonPressed.setRandom = true;
   runNextFrame(1000 * (1 / 60) + 1, jest.fn());
 
   expect(logSpy).toBeCalledWith(0.5);
@@ -304,7 +304,7 @@ test("can provide a random number", () => {
 });
 
 test("supports timer", async () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const startSpy = jest.spyOn(mutableTestDevice.timer, "start");
   const cancelSpy = jest.spyOn(mutableTestDevice.timer, "cancel");
   const pauseSpy = jest.spyOn(mutableTestDevice.timer, "pause");
@@ -323,7 +323,7 @@ test("supports timer", async () => {
     runNextFrame(time, jest.fn());
   };
 
-  mutableTestDevice.inputs.buttonPressed.timer.start = true;
+  mutInputs.ref.buttonPressed.timer.start = true;
   nextFrame();
 
   await waitFrame();
@@ -331,27 +331,27 @@ test("supports timer", async () => {
   expect(logSpy).toBeCalledWith("timeout complete");
   expect(startSpy).toBeCalledTimes(2); // once in init
 
-  mutableTestDevice.inputs.buttonPressed.timer.start = false;
-  mutableTestDevice.inputs.buttonPressed.timer.pause = "abc";
+  mutInputs.ref.buttonPressed.timer.start = false;
+  mutInputs.ref.buttonPressed.timer.pause = "abc";
   nextFrame();
   expect(pauseSpy).toBeCalledTimes(1);
   expect(pauseSpy).toBeCalledWith("abc");
 
-  mutableTestDevice.inputs.buttonPressed.timer.pause = "";
-  mutableTestDevice.inputs.buttonPressed.timer.resume = "abc";
+  mutInputs.ref.buttonPressed.timer.pause = "";
+  mutInputs.ref.buttonPressed.timer.resume = "abc";
   nextFrame();
   expect(resumeSpy).toBeCalledTimes(1);
   expect(resumeSpy).toBeCalledWith("abc");
 
-  mutableTestDevice.inputs.buttonPressed.timer.resume = "";
-  mutableTestDevice.inputs.buttonPressed.timer.cancel = "abc";
+  mutInputs.ref.buttonPressed.timer.resume = "";
+  mutInputs.ref.buttonPressed.timer.cancel = "abc";
   nextFrame();
   expect(cancelSpy).toBeCalledTimes(1);
   expect(cancelSpy).toBeCalledWith("abc");
 });
 
 test("supports getting date now", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const setDateSpy = jest.spyOn(mutableTestDevice, "now");
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
@@ -361,7 +361,7 @@ test("supports getting date now", () => {
     FullTestGame(gameProps)
   );
 
-  mutableTestDevice.inputs.buttonPressed.setDate = true;
+  mutInputs.ref.buttonPressed.setDate = true;
   runNextFrame(1000 * (1 / 60) + 1, jest.fn());
 
   expect(logSpy).toBeCalledWith("1996-01-17T03:24:00.000Z");
@@ -369,7 +369,7 @@ test("supports getting date now", () => {
 });
 
 test("supports updateState", async () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
   const { runNextFrame } = replayCore(
@@ -389,7 +389,7 @@ test("supports updateState", async () => {
   nextFrame();
   expect(logSpy).toBeCalledWith("initialised");
 
-  mutableTestDevice.inputs.buttonPressed.action = true;
+  mutInputs.ref.buttonPressed.action = true;
   nextFrame();
   await waitFrame();
   nextFrame(); // log called on state change in next loop
@@ -400,7 +400,7 @@ test("supports updateState", async () => {
 });
 
 test("updateState in loop will update state in next render", () => {
-  const { platform, mutableTestDevice, textures } = getTestPlatform();
+  const { platform, mutInputs, textures } = getTestPlatform();
 
   const { runNextFrame } = replayCore(
     platform,
@@ -416,8 +416,8 @@ test("updateState in loop will update state in next render", () => {
     runNextFrame(time, jest.fn());
   };
 
-  mutableTestDevice.inputs.buttonPressed.move = true;
-  mutableTestDevice.inputs.buttonPressed.moveWithUpdateState = true;
+  mutInputs.ref.buttonPressed.move = true;
+  mutInputs.ref.buttonPressed.moveWithUpdateState = true;
 
   nextFrame();
 
@@ -426,10 +426,15 @@ test("updateState in loop will update state in next render", () => {
 });
 
 test("can call updateState within an updateState", async () => {
-  const { platform, mutableTestDevice, textures } = getTestPlatform();
+  const {
+    platform,
+    mutableTestDevice,
+    mutInputs,
+    textures,
+  } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
-  mutableTestDevice.inputs.buttonPressed.action = true;
+  mutInputs.ref.buttonPressed.action = true;
 
   const { runNextFrame } = replayCore(
     platform,
@@ -459,7 +464,7 @@ test("can call updateState within an updateState", async () => {
 });
 
 test("supports getState", async () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
   const { runNextFrame } = replayCore(
@@ -468,7 +473,7 @@ test("supports getState", async () => {
     FullTestGame(gameProps)
   );
 
-  mutableTestDevice.inputs.buttonPressed.move = true;
+  mutInputs.ref.buttonPressed.move = true;
 
   let time = 1;
   const nextFrame = () => {
@@ -491,7 +496,7 @@ test("getState will throw error if called synchronously", () => {
 });
 
 test("supports playing audio", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
   const audio = mutableTestDevice.audio("filename");
@@ -513,34 +518,34 @@ test("supports playing audio", () => {
     runNextFrame(time, jest.fn());
   };
 
-  mutableTestDevice.inputs.buttonPressed.sound.play = true;
+  mutInputs.ref.buttonPressed.sound.play = true;
   nextFrame();
   expect(audioSpy.play).toBeCalledWith();
 
-  mutableTestDevice.inputs.buttonPressed.sound.playFromPosition = true;
+  mutInputs.ref.buttonPressed.sound.playFromPosition = true;
   nextFrame();
   expect(audioSpy.play).toBeCalledWith(100);
 
-  mutableTestDevice.inputs.buttonPressed.sound.playLoop = true;
+  mutInputs.ref.buttonPressed.sound.playLoop = true;
   nextFrame();
   expect(audioSpy.play).toBeCalledWith({ fromPosition: 0, loop: true });
 
-  mutableTestDevice.inputs.buttonPressed.sound.playOverwrite = true;
+  mutInputs.ref.buttonPressed.sound.playOverwrite = true;
   nextFrame();
   expect(audioSpy.play).toBeCalledWith({ overwrite: true });
 
-  mutableTestDevice.inputs.buttonPressed.sound.pause = true;
+  mutInputs.ref.buttonPressed.sound.pause = true;
   nextFrame();
   expect(audioSpy.pause).toBeCalledWith();
 
-  mutableTestDevice.inputs.buttonPressed.sound.getPosition = true;
+  mutInputs.ref.buttonPressed.sound.getPosition = true;
   nextFrame();
   expect(audioSpy.getPosition).toBeCalledWith();
   expect(logSpy).toBeCalledWith(50);
 });
 
 test("supports network calls", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
   const { network } = mutableTestDevice;
@@ -563,22 +568,22 @@ test("supports network calls", () => {
     runNextFrame(time, jest.fn());
   };
 
-  mutableTestDevice.inputs.buttonPressed.network.get = true;
+  mutInputs.ref.buttonPressed.network.get = true;
   nextFrame();
   expect(networkSpy.get).toBeCalled();
   expect(logSpy).toBeCalledWith("GET-/test");
 
-  mutableTestDevice.inputs.buttonPressed.network.put = true;
+  mutInputs.ref.buttonPressed.network.put = true;
   nextFrame();
   expect(networkSpy.put).toBeCalled();
   expect(logSpy).toBeCalledWith("PUT-/test-PUT_BODY");
 
-  mutableTestDevice.inputs.buttonPressed.network.post = true;
+  mutInputs.ref.buttonPressed.network.post = true;
   nextFrame();
   expect(networkSpy.post).toBeCalled();
   expect(logSpy).toBeCalledWith("POST-/test-POST_BODY");
 
-  mutableTestDevice.inputs.buttonPressed.network.delete = true;
+  mutInputs.ref.buttonPressed.network.delete = true;
   nextFrame();
   expect(networkSpy.delete).toBeCalled();
   expect(logSpy).toBeCalledWith("DELETE-/test");
@@ -648,7 +653,7 @@ test("supports local storage", async () => {
 });
 
 test("supports alerts", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
   const { alert } = mutableTestDevice;
@@ -669,19 +674,19 @@ test("supports alerts", () => {
     runNextFrame(time, jest.fn());
   };
 
-  mutableTestDevice.inputs.buttonPressed.alert.ok = true;
+  mutInputs.ref.buttonPressed.alert.ok = true;
   nextFrame();
   expect(alertSpy.ok).toBeCalled();
   expect(logSpy).toBeCalledWith("Hit ok");
 
-  mutableTestDevice.inputs.buttonPressed.alert.okCancel = true;
+  mutInputs.ref.buttonPressed.alert.okCancel = true;
   nextFrame();
   expect(alertSpy.okCancel).toBeCalled();
   expect(logSpy).toBeCalledWith("Was ok: true");
 });
 
 test("can copy to clipboard", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
   const { clipboard } = mutableTestDevice;
@@ -703,8 +708,7 @@ test("can copy to clipboard", () => {
 
   expect(clipboardSpy.copy).not.toHaveBeenCalled();
 
-  mutableTestDevice.inputs.buttonPressed.clipboard.copyMessage =
-    "Hello clipboard";
+  mutInputs.ref.buttonPressed.clipboard.copyMessage = "Hello clipboard";
   nextFrame();
   expect(clipboardSpy.copy).toBeCalledWith(
     "Hello clipboard",
@@ -712,7 +716,7 @@ test("can copy to clipboard", () => {
   );
   expect(logSpy).toBeCalledWith("Copied");
 
-  mutableTestDevice.inputs.buttonPressed.clipboard.copyMessage = "Error";
+  mutInputs.ref.buttonPressed.clipboard.copyMessage = "Error";
   nextFrame();
   expect(clipboardSpy.copy).toBeCalledWith("Error", expect.any(Function));
   expect(logSpy).toBeCalledWith("Error copying: !");
@@ -808,11 +812,16 @@ test("deeply nested input position", () => {
   // Note: deeply nested sprite positions are handled by the platforms (there's
   // a test case for this in replay-test)
 
-  const { platform, mutableTestDevice, textures } = getTestPlatform();
+  const {
+    platform,
+    mutableTestDevice,
+    mutInputs,
+    textures,
+  } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
-  mutableTestDevice.inputs.x = 50;
-  mutableTestDevice.inputs.y = 50;
+  mutInputs.ref.x = 50;
+  mutInputs.ref.y = 50;
 
   replayCore(platform, nativeSpriteSettings, NestedSpriteGame(gameProps));
 
@@ -834,11 +843,11 @@ test("deeply nested input position", () => {
 });
 
 test("nested sprites and input position with scale", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const logSpy = jest.spyOn(mutableTestDevice, "log");
 
-  mutableTestDevice.inputs.x = 10;
-  mutableTestDevice.inputs.y = 10;
+  mutInputs.ref.x = 10;
+  mutInputs.ref.y = 10;
 
   replayCore(platform, nativeSpriteSettings, NestedSpriteGame2(gameProps));
 
@@ -887,7 +896,12 @@ test("loop and render order for callback prop change on low render FPS", () => {
 });
 
 test("can preload and clear file assets", async () => {
-  const { platform, mutableTestDevice, textures } = getTestPlatform();
+  const {
+    platform,
+    mutableTestDevice,
+    mutInputs,
+    textures,
+  } = getTestPlatform();
   const resetInputs = jest.fn();
 
   const { runNextFrame } = replayCore(
@@ -974,7 +988,7 @@ test("can preload and clear file assets", async () => {
   });
 
   // Unmount Sprites
-  mutableTestDevice.inputs.buttonPressed.show = false;
+  mutInputs.ref.buttonPressed.show = false;
   nextFrame();
 
   // Need resolved promise to be called
@@ -988,7 +1002,7 @@ test("can preload and clear file assets", async () => {
 });
 
 test("Sprite unmounted before it loads", async () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
   const resetInputs = jest.fn();
 
   const { runNextFrame } = replayCore(
@@ -1011,7 +1025,7 @@ test("Sprite unmounted before it loads", async () => {
   expect(mutableTestDevice.assetUtils.loadImageFile).toHaveBeenCalledTimes(2);
 
   // Unmount Sprites before they finish loading
-  mutableTestDevice.inputs.buttonPressed.show = false;
+  mutInputs.ref.buttonPressed.show = false;
   nextFrame();
 
   // Wait for promises to load
@@ -1036,7 +1050,7 @@ test("throws error on duplicate Sprites", () => {
 });
 
 test("supports Pure Sprites", () => {
-  const { platform, mutableTestDevice } = getTestPlatform();
+  const { platform, mutInputs } = getTestPlatform();
 
   const { runNextFrame } = replayCore(
     platform,
@@ -1060,7 +1074,7 @@ test("supports Pure Sprites", () => {
   expect(pureSpriteNeverRendersFn).toBeCalledTimes(1);
   expect(pureSpriteConditionalRendersFn).toBeCalledTimes(1);
 
-  mutableTestDevice.inputs.buttonPressed.show = false;
+  mutInputs.ref.buttonPressed.show = false;
   nextFrame();
 
   expect(pureSpriteAlwaysRendersFn).toBeCalledTimes(3);
@@ -1069,7 +1083,7 @@ test("supports Pure Sprites", () => {
 });
 
 test("supports Native Sprites", () => {
-  const { platform, mutableTestDevice, textures } = getTestPlatform();
+  const { platform, mutInputs, textures } = getTestPlatform();
 
   const mutableNativeSpriteUtils: NativeSpriteUtils = {
     didResize: false,
@@ -1122,7 +1136,7 @@ test("supports Native Sprites", () => {
   expect(widgetState.x).toBe(20);
 
   // test cleanup
-  mutableTestDevice.inputs.x = 100;
+  mutInputs.ref.x = 100;
   nextFrame();
   expect(widgetState.text).toBe("");
 });

--- a/packages/replay-core/src/device.ts
+++ b/packages/replay-core/src/device.ts
@@ -1,9 +1,7 @@
 /**
  * The type of a device that supports Replay
  */
-export interface Device<I = unknown> {
-  inputs: I;
-
+export interface Device {
   /**
    * Is the device a touch screen device - e.g. show buttons instead of relying
    * on pinch gesture for zooming if there's no touch available.

--- a/packages/replay-core/src/props.ts
+++ b/packages/replay-core/src/props.ts
@@ -69,3 +69,18 @@ export function getDefaultProps(
     mask: props.mask || null,
   };
 }
+
+export function mutateBaseProps(
+  prevBaseProps: SpriteBaseProps,
+  props: Partial<SpriteBaseProps>
+) {
+  prevBaseProps.x = props.x || 0;
+  prevBaseProps.y = props.y || 0;
+  prevBaseProps.rotation = props.rotation || 0;
+  prevBaseProps.opacity = Math.min(1, Math.max(0, props.opacity ?? 1));
+  prevBaseProps.scaleX = props.scaleX ?? 1;
+  prevBaseProps.scaleY = props.scaleY ?? 1;
+  prevBaseProps.anchorX = props.anchorX || 0;
+  prevBaseProps.anchorY = props.anchorY || 0;
+  prevBaseProps.mask = props.mask || null;
+}

--- a/packages/replay-core/src/sprite.ts
+++ b/packages/replay-core/src/sprite.ts
@@ -221,16 +221,6 @@ type PureSpriteObj<P> = {
 };
 
 /**
- * A nesting of textures sent to the platform to render. The nesting allows for
- * things like transforms on a Sprite.
- */
-export type SpriteTextures = {
-  id: string;
-  baseProps: SpriteBaseProps;
-  textures: (SpriteTextures | Texture)[];
-};
-
-/**
  * Native Sprites are custom platform-specific elements not inside Replay
  * itself, like text inputs. Their name is stored, and implementation
  * dynamically looked up within each platform.

--- a/packages/replay-core/src/sprite.ts
+++ b/packages/replay-core/src/sprite.ts
@@ -71,7 +71,8 @@ interface SpriteObjInit<P, S, I> {
      * returns it will throw an error.
      */
     getState: () => S;
-    device: Device<I>;
+    device: Device;
+    getInputs: () => I;
     updateState: (update: (state: S) => S) => void;
     /**
      * Asset file names to preload for this Sprite. They'll be cleared from
@@ -88,7 +89,8 @@ interface SpriteObjBase<P, S, I> {
   loop?: (params: {
     props: Readonly<P>;
     state: Readonly<S>;
-    device: Device<I>;
+    device: Device;
+    getInputs: () => I;
     updateState: (update: (state: S) => S) => void;
     getState: () => S;
   }) => S;
@@ -102,7 +104,8 @@ interface SpriteObjBase<P, S, I> {
   render: (params: {
     props: Readonly<P>;
     state: Readonly<S>;
-    device: Device<I>;
+    device: Device;
+    getInputs: () => I;
     updateState: (update: (state: S) => S) => void;
     getState: () => S;
     /**
@@ -120,7 +123,8 @@ interface SpriteObjBase<P, S, I> {
   renderP?: (params: {
     props: Readonly<P>;
     state: Readonly<S>;
-    device: Device<I>;
+    device: Device;
+    getInputs: () => I;
     updateState: (update: (state: S) => S) => void;
     getState: () => S;
   }) => Sprite[];
@@ -132,7 +136,8 @@ interface SpriteObjBase<P, S, I> {
   renderXL?: (params: {
     props: Readonly<P>;
     state: Readonly<S>;
-    device: Device<I>;
+    device: Device;
+    getInputs: () => I;
     updateState: (update: (state: S) => S) => void;
     getState: () => S;
   }) => Sprite[];
@@ -146,7 +151,8 @@ interface SpriteObjBase<P, S, I> {
   renderPXL?: (params: {
     props: Readonly<P>;
     state: Readonly<S>;
-    device: Device<I>;
+    device: Device;
+    getInputs: () => I;
     updateState: (update: (state: S) => S) => void;
     getState: () => S;
   }) => Sprite[];

--- a/packages/replay-core/src/sprite.ts
+++ b/packages/replay-core/src/sprite.ts
@@ -34,11 +34,13 @@ export function makeSprite<
 >(
   spriteObj: SpriteObj<P, S, I>
 ): (props: CustomSpriteProps<P>) => CustomSprite<P, S, I> {
-  return (props) => ({
-    type: "custom",
-    spriteObj,
-    props,
-  });
+  return function makeSpriteCallback(props) {
+    return {
+      type: "custom",
+      spriteObj,
+      props,
+    };
+  };
 }
 
 export interface CustomSprite<P, S, I> {
@@ -182,11 +184,13 @@ export type PureCustomSprite<P> = {
 export function makePureSprite<P extends ExcludeSpriteBaseProps<P>>(
   spriteObj: PureSpriteObj<P>
 ): (props: CustomSpriteProps<P>) => PureCustomSprite<P> {
-  return (props) => ({
-    type: "pure",
-    spriteObj,
-    props,
-  });
+  return function makePureSpriteCallback(props) {
+    return {
+      type: "pure",
+      spriteObj,
+      props,
+    };
+  };
 }
 
 type PureSpriteObj<P> = {

--- a/packages/replay-starter-js/src/index.js
+++ b/packages/replay-starter-js/src/index.js
@@ -42,10 +42,10 @@ export const Game = makeSprite({
     };
   },
 
-  loop({ state, device }) {
+  loop({ state, device, getInputs }) {
     if (!state.loaded) return state;
 
-    const { pointer } = device.inputs;
+    const { pointer } = getInputs();
     const { posX, posY } = state;
     let { targetX, targetY } = state;
 

--- a/packages/replay-starter-ts/src/index.ts
+++ b/packages/replay-starter-ts/src/index.ts
@@ -52,10 +52,10 @@ export const Game = makeSprite<GameProps, GameState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ state, device }) {
+  loop({ state, device, getInputs }) {
     if (!state.loaded) return state;
 
-    const { pointer } = device.inputs;
+    const { pointer } = getInputs();
     const { posX, posY } = state;
     let { targetX, targetY } = state;
 

--- a/packages/replay-test/src/__tests__/replay-test.test.ts
+++ b/packages/replay-test/src/__tests__/replay-test.test.ts
@@ -673,14 +673,15 @@ const Game = makeSprite<GameProps, State, Inputs>({
     };
   },
 
-  loop({ state, device, updateState }) {
-    if (device.inputs.pressed) {
+  loop({ state, device, getInputs, updateState }) {
+    const inputs = getInputs();
+    if (inputs.pressed) {
       return {
         ...state,
         x: state.x + 1,
       };
     }
-    switch (device.inputs.testInput) {
+    switch (inputs.testInput) {
       case "logRandom":
         device.log(device.random());
         break;
@@ -820,9 +821,10 @@ const Game = makeSprite<GameProps, State, Inputs>({
 });
 
 const Text = makeSprite<{ text: string }, undefined, Inputs>({
-  render({ props, device }) {
-    if (device.inputs.x) {
-      device.log(`x in Text Sprite is ${device.inputs.x}`);
+  render({ props, device, getInputs }) {
+    const inputs = getInputs();
+    if (inputs.x) {
+      device.log(`x in Text Sprite is ${inputs.x}`);
     }
     return [
       t.text({

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -229,17 +229,6 @@ export function testSprite<P, S, I>(
   };
 
   let inputs: I = { ...initInputs };
-  function getInputs(
-    globalToLocalCoords: (globalCoords: {
-      x: number;
-      y: number;
-    }) => {
-      x: number;
-      y: number;
-    }
-  ) {
-    return mapInputCoordinates(globalToLocalCoords, inputs);
-  }
   /**
    * Update the current input state in the game.
    */
@@ -276,7 +265,7 @@ export function testSprite<P, S, I>(
     return randomNumber;
   };
 
-  const audioFn: Device<I>["audio"] = (filename) => {
+  const audioFn: Device["audio"] = (filename) => {
     if (throwAssetErrors) {
       const audioElement = audioElements[filename];
       if (!audioElement) {
@@ -302,7 +291,7 @@ export function testSprite<P, S, I>(
     };
   };
 
-  const timer: Device<I>["timer"] = {
+  const timer: Device["timer"] = {
     start: (callback, ms) => {
       // Get a unique ID
       let id = "";
@@ -340,7 +329,7 @@ export function testSprite<P, S, I>(
   };
 
   const store = { ...initStore };
-  const storage: Device<I>["storage"] = {
+  const storage: Device["storage"] = {
     getItem(key) {
       return Promise.resolve(store[key] ?? null);
     },
@@ -374,41 +363,36 @@ export function testSprite<P, S, I>(
   const getPosStack: ((localCoords: Pos) => Pos)[] = [];
 
   const testPlatform: ReplayPlatform<I> = {
-    getGetDevice: () => {
-      const now = () => {
-        return new Date(Date.UTC(2000, 1, 1));
-      };
-      // called individually by each Sprite
-      return (globalToLocalCoords) => ({
-        inputs: getInputs(globalToLocalCoords),
-        isTouchScreen,
-        size,
-        log,
-        random,
-        timer,
-        now,
-        audio: audioFn,
-        assetUtils: {
-          audioElements,
-          imageElements,
-          loadAudioFile: (fileName) => {
-            return Promise.resolve().then(() => {
-              return `audioData-${fileName}`;
-            });
-          },
-          loadImageFile: (fileName) => {
-            return Promise.resolve().then(() => {
-              return `imageData-${fileName}`;
-            });
-          },
-          cleanupAudioFile: () => null,
-          cleanupImageFile: () => null,
+    getInputs: (globalToLocalCoords) =>
+      mapInputCoordinates(globalToLocalCoords, inputs),
+    mutDevice: {
+      isTouchScreen,
+      size,
+      log,
+      random,
+      timer,
+      now: () => new Date(Date.UTC(2000, 1, 1)),
+      audio: audioFn,
+      assetUtils: {
+        audioElements,
+        imageElements,
+        loadAudioFile: (fileName) => {
+          return Promise.resolve().then(() => {
+            return `audioData-${fileName}`;
+          });
         },
-        network,
-        storage,
-        alert,
-        clipboard,
-      });
+        loadImageFile: (fileName) => {
+          return Promise.resolve().then(() => {
+            return `imageData-${fileName}`;
+          });
+        },
+        cleanupAudioFile: () => null,
+        cleanupImageFile: () => null,
+      },
+      network,
+      storage,
+      alert,
+      clipboard,
     },
     render: {
       newFrame: () => {

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -2,11 +2,7 @@
 
 import { GameProps, Texture, Device, DeviceSize } from "@replay/core";
 import { replayCore, ReplayPlatform } from "@replay/core/dist/core";
-import {
-  CustomSprite,
-  makeSprite,
-  SpriteTextures,
-} from "@replay/core/dist/sprite";
+import { CustomSprite, makeSprite } from "@replay/core/dist/sprite";
 import { TextTexture } from "@replay/core/dist/t";
 import { getParentCoordsForSprite } from "./coords";
 import { NativeSpriteMock } from "./nativeSpriteMock";
@@ -371,6 +367,12 @@ export function testSprite<P, S, I>(
   const audioElements: AssetMap<string> = {};
   const imageElements: AssetMap<string> = {};
 
+  type Pos = { x: number; y: number; rotation: number };
+  /**
+   * Keep a stack of functions mapping local to global coords
+   */
+  const getPosStack: ((localCoords: Pos) => Pos)[] = [];
+
   const testPlatform: ReplayPlatform<I> = {
     getGetDevice: () => {
       const now = () => {
@@ -408,6 +410,57 @@ export function testSprite<P, S, I>(
         clipboard,
       });
     },
+    render: {
+      newFrame: () => {
+        textures.length = 0;
+      },
+      startRenderSprite: (baseProps) => {
+        const getParentCoords = getParentCoordsForSprite(baseProps);
+
+        const getParentPos = ({ x, y, rotation }: Pos) => ({
+          ...getParentCoords({ x, y }),
+          rotation: rotation + baseProps.rotation,
+        });
+
+        getPosStack.unshift(getParentPos);
+      },
+      endRenderSprite: () => {
+        getPosStack.shift();
+      },
+      renderTexture: (texture) => {
+        if (
+          throwAssetErrors &&
+          (texture.type === "image" || texture.type === "spriteSheet")
+        ) {
+          const fileName = texture.props.fileName;
+          const imageElement = imageElements[fileName];
+          if (!imageElement) {
+            throw Error(`Image file "${fileName}" was not preloaded`);
+          }
+          if (typeof imageElement.data === "object") {
+            throw Error(
+              `Image file "${fileName}" did not finish loading before it was used`
+            );
+          }
+        }
+
+        // Go through all functions mapping position
+        const { x, y, rotation } = getPosStack.reduce(
+          (pos, posFn) => posFn(pos),
+          texture.props as Pos
+        );
+
+        textures.push({
+          ...texture,
+          props: {
+            ...texture.props,
+            x: Math.round(x),
+            y: Math.round(y),
+            rotation: Math.round(rotation),
+          },
+        } as Texture);
+      },
+    },
   };
 
   const TestContainer = makeSprite<GameProps>({
@@ -416,7 +469,7 @@ export function testSprite<P, S, I>(
     },
   });
 
-  const { initTextures, getNextFrameTextures } = replayCore(
+  const { runNextFrame } = replayCore(
     testPlatform,
     {
       // Mock the Native Sprites passed in to avoid errors when looked up
@@ -452,73 +505,13 @@ export function testSprite<P, S, I>(
     });
   }
 
-  function render(newTextures: SpriteTextures) {
-    // Mutably replace textures with new textures
-    textures.length = 0;
-
-    type Pos = { x: number; y: number; rotation: number };
-
-    const traverseSpriteTextures = (
-      spriteTextures: SpriteTextures | Texture,
-      getParentGlobalPos: (localCoords: Pos) => Pos
-    ) => {
-      if ("type" in spriteTextures) {
-        // is a Texture
-        const { x, y, rotation } = getParentGlobalPos(spriteTextures.props);
-
-        // Output textures with global coordinates and rotation
-        textures.push({
-          ...spriteTextures,
-          props: {
-            ...spriteTextures.props,
-            x: Math.round(x),
-            y: Math.round(y),
-            rotation: Math.round(rotation),
-          },
-        } as Texture);
-
-        if (
-          throwAssetErrors &&
-          (spriteTextures.type === "image" ||
-            spriteTextures.type === "spriteSheet")
-        ) {
-          const fileName = spriteTextures.props.fileName;
-          const imageElement = imageElements[fileName];
-          if (!imageElement) {
-            throw Error(`Image file "${fileName}" was not preloaded`);
-          }
-          if (typeof imageElement.data === "object") {
-            throw Error(
-              `Image file "${fileName}" did not finish loading before it was used`
-            );
-          }
-        }
-
-        return;
-      }
-
-      const { baseProps } = spriteTextures;
-      const getParentCoords = getParentCoordsForSprite(baseProps);
-      const getGlobalPos = ({ x, y, rotation }: Pos) =>
-        getParentGlobalPos({
-          ...getParentCoords({ x, y }),
-          rotation: rotation + baseProps.rotation,
-        });
-
-      spriteTextures.textures.forEach((childSpriteTextures) => {
-        traverseSpriteTextures(childSpriteTextures, getGlobalPos);
-      });
-    };
-    traverseSpriteTextures(newTextures, (pos) => pos);
-  }
-
   /**
    * Synchronously progress to the next frame of the game.
    */
   function nextFrame() {
     gameTime += 1000 / 60;
     checkTimers();
-    render(getNextFrameTextures(gameTime, jest.fn()));
+    runNextFrame(gameTime, jest.fn());
   }
 
   /**
@@ -623,9 +616,6 @@ export function testSprite<P, S, I>(
         texture.props.text.toLowerCase().includes(text.toLowerCase())
       );
   }
-
-  // Init render
-  render(initTextures);
 
   return {
     nextFrame,

--- a/packages/replay-text-input/src/__tests__/game.ts
+++ b/packages/replay-text-input/src/__tests__/game.ts
@@ -19,16 +19,16 @@ export const gameProps: GameProps = {
 };
 
 export const Game = makeSprite<GameProps, State, iOSInputs | WebInputs>({
-  init({ device }) {
-    const { pointer } = device.inputs;
+  init({ getInputs }) {
+    const { pointer } = getInputs();
     return {
       view: getViewFromPointer(pointer.x),
       textValue: "Hello",
     };
   },
 
-  loop({ state, device, updateState }) {
-    const { pointer } = device.inputs;
+  loop({ state, getInputs, updateState }) {
+    const { pointer } = getInputs();
 
     if (pointer.justPressed) {
       updateState((s) => ({ ...s, view: getViewFromPointer(pointer.x) }));

--- a/packages/replay-web/src/__tests__/draw.test.ts
+++ b/packages/replay-web/src/__tests__/draw.test.ts
@@ -1,8 +1,6 @@
 import { drawCanvas } from "../draw";
 import { canvasToImage } from "./utils";
-import { t, DeviceSize, mask } from "@replay/core";
-import { SpriteTextures } from "@replay/core/dist/sprite";
-import { getDefaultProps } from "@replay/core/dist/props";
+import { t, DeviceSize, mask, Texture } from "@replay/core";
 
 const deviceSize: DeviceSize = {
   width: 300,
@@ -14,7 +12,7 @@ const deviceSize: DeviceSize = {
 };
 
 let canvas: HTMLCanvasElement;
-let render: (textures: SpriteTextures["textures"]) => void;
+let render: (textures: Texture[]) => void;
 
 beforeAll(() => {
   render = (textures) => {
@@ -23,11 +21,14 @@ beforeAll(() => {
     canvas.height = 500;
     const ctx = canvas.getContext("2d", { alpha: false })!;
 
-    drawCanvas(ctx, deviceSize, {}, { family: "Courier", size: 12 }).render({
-      id: "test",
-      baseProps: getDefaultProps({}),
-      textures,
-    });
+    const renderTexture = drawCanvas(
+      ctx,
+      deviceSize,
+      {},
+      { family: "Courier", size: 12 }
+    ).render.renderTexture;
+
+    textures.forEach(renderTexture);
   };
 });
 

--- a/packages/replay-web/src/__tests__/inputs.test.ts
+++ b/packages/replay-web/src/__tests__/inputs.test.ts
@@ -80,7 +80,8 @@ const KeyboardGame = makeSprite<GameProps, KeyboardState, Inputs>({
       isUpKeyJustPressed: false,
     };
   },
-  loop({ device: { inputs } }) {
+  loop({ getInputs }) {
+    const inputs = getInputs();
     return {
       isUpKeyPressed: inputs.keysDown.ArrowUp || false,
       isUpKeyJustPressed: inputs.keysJustPressed.ArrowUp || false,
@@ -323,7 +324,8 @@ const PointerGame = makeSprite<GameProps, PointerState, Inputs>({
       pointerY: 0,
     };
   },
-  loop({ device: { inputs } }) {
+  loop({ getInputs }) {
+    const inputs = getInputs();
     return {
       pointerPressed: inputs.pointer.pressed,
       pointerJustPressed: inputs.pointer.justPressed,
@@ -388,7 +390,8 @@ const PointerSprite = makeSprite<{}, PointerState, Inputs>({
       pointerY: 0,
     };
   },
-  loop({ device: { inputs } }) {
+  loop({ getInputs }) {
+    const inputs = getInputs();
     return {
       pointerPressed: inputs.pointer.pressed,
       pointerJustPressed: inputs.pointer.justPressed,

--- a/packages/replay-web/src/__tests__/utils.ts
+++ b/packages/replay-web/src/__tests__/utils.ts
@@ -31,10 +31,11 @@ export const TestGame = makeSprite<
     return { position: 0, timerId: null };
   },
 
-  loop({ state, device, updateState }) {
-    const posInc = device.inputs.keysDown.ArrowRight ? 10 : 0;
+  loop({ state, device, updateState, getInputs }) {
+    const inputs = getInputs();
+    const posInc = inputs.keysDown.ArrowRight ? 10 : 0;
 
-    const { pointer } = device.inputs;
+    const { pointer } = inputs;
     if (pointer.justPressed) {
       if (pointer.x === 1) {
         device.log(device.now().toUTCString());
@@ -133,8 +134,9 @@ const TestSprite = makeSprite<TestGameProps, TestGameState, Inputs>({
     return { position: 0 };
   },
 
-  loop({ state, device }) {
-    const posInc = device.inputs.keysDown.ArrowRight ? 10 : 0;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
+    const posInc = inputs.keysDown.ArrowRight ? 10 : 0;
     return { position: state.position + posInc };
   },
 
@@ -174,13 +176,15 @@ export const TestGameWithAssets = makeSprite<
     return { position: 0, rotation: 0, loading: true };
   },
 
-  loop({ state, device }) {
+  loop({ state, device, getInputs }) {
     if (state.loading) return state;
 
-    const posInc = device.inputs.keysDown.ArrowRight ? 10 : 0;
-    const rotInc = device.inputs.keysDown.ArrowRight ? 45 : 0;
+    const inputs = getInputs();
 
-    const { pointer } = device.inputs;
+    const posInc = inputs.keysDown.ArrowRight ? 10 : 0;
+    const rotInc = inputs.keysDown.ArrowRight ? 45 : 0;
+
+    const { pointer } = inputs;
     if (pointer.justPressed) {
       if (pointer.x === 1) {
         device.audio("shoot.wav").play();
@@ -330,8 +334,9 @@ export const TestAssetsGame = makeSprite<
     return { loading: true, show: true };
   },
 
-  loop({ state, device }) {
-    return { ...state, show: !device.inputs.pointer.pressed };
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
+    return { ...state, show: !inputs.pointer.pressed };
   },
 
   render({ state }) {
@@ -368,8 +373,9 @@ export const TestGameWithNativeSprite = makeSprite<
   undefined,
   Inputs
 >({
-  render({ device }) {
-    if (device.inputs.pointer.pressed) {
+  render({ getInputs }) {
+    const inputs = getInputs();
+    if (inputs.pointer.pressed) {
       return [];
     }
     return [TestNativeSprite({ id: "test" })];

--- a/packages/replay-web/src/device.ts
+++ b/packages/replay-web/src/device.ts
@@ -33,7 +33,7 @@ export type ImageFileData = HTMLImageElement;
 export function getAudio(
   audioContext: AudioContext,
   audioElements: AssetMap<AudioData>
-): Device<{}>["audio"] {
+): Device["audio"] {
   return (fileName) => {
     const audioElement = audioElements[fileName];
     if (!audioElement) {
@@ -137,7 +137,7 @@ function getAudioPosition(
   return 0;
 }
 
-export function getNetwork(): Device<{}>["network"] {
+export function getNetwork(): Device["network"] {
   return {
     get: (url, callback) => {
       fetch(url)
@@ -170,7 +170,7 @@ export function getNetwork(): Device<{}>["network"] {
   };
 }
 
-export function getStorage(): Device<{}>["storage"] {
+export function getStorage(): Device["storage"] {
   return {
     getItem: async (key) => {
       return localStorage.getItem(key);
@@ -185,7 +185,7 @@ export function getStorage(): Device<{}>["storage"] {
   };
 }
 
-export function getClipboard(): Device<{}>["clipboard"] {
+export function getClipboard(): Device["clipboard"] {
   return {
     copy: (text, onComplete) => {
       if (!navigator.clipboard) {

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -72,6 +72,14 @@ export type RenderCanvasOptions = {
    * Override the view size, instead of using the window size
    */
   windowSize?: { width: number; height: number };
+  /**
+   * Start your own timer to test game's performance
+   */
+  statsBegin?: () => void;
+  /**
+   * End of timer to test game's performance
+   */
+  statsEnd?: () => void;
 };
 
 type PlatformOptions = {
@@ -97,6 +105,8 @@ export function renderCanvas<S>(
     canvas: userCanvas,
     nativeSpriteMap = {},
     windowSize,
+    statsBegin,
+    statsEnd,
   } = options || {};
 
   const canvas = userCanvas || document.createElement("canvas");
@@ -445,10 +455,12 @@ export function renderCanvas<S>(
 
   function loop(textures: SpriteTextures) {
     render.ref?.(textures);
+    statsEnd?.();
     window.requestAnimationFrame((time) => {
       if (isCleanedUp) {
         return;
       }
+      statsBegin?.();
       if (initTime === null) {
         initTime = time - 1 / 60;
       }

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -3,12 +3,9 @@ import {
   replayCore,
   ReplayPlatform,
   NativeSpriteMap,
+  PlatformRender,
 } from "@replay/core/dist/core";
-import {
-  CustomSprite,
-  SpriteTextures,
-  NativeSpriteUtils,
-} from "@replay/core/dist/sprite";
+import { CustomSprite, NativeSpriteUtils } from "@replay/core/dist/sprite";
 import { AssetUtils, AssetMap } from "@replay/core/dist/device";
 import {
   getInputs,
@@ -235,7 +232,12 @@ export function renderCanvas<S>(
       defaultFont
     );
     scale = renderCanvasResult.scale;
-    render.ref = renderCanvasResult.render;
+
+    // Mutate render
+    mutRender.newFrame = renderCanvasResult.render.newFrame;
+    mutRender.startRenderSprite = renderCanvasResult.render.startRenderSprite;
+    mutRender.endRenderSprite = renderCanvasResult.render.endRenderSprite;
+    mutRender.renderTexture = renderCanvasResult.render.renderTexture;
 
     nativeSpriteUtils.gameXToPlatformX = getGameXToWebX({
       canvasOffsetLeft: canvas.offsetLeft,
@@ -398,6 +400,13 @@ export function renderCanvas<S>(
     cleanupImageFile: () => null,
   };
 
+  const mutRender: PlatformRender = {
+    newFrame: () => null,
+    startRenderSprite: () => null,
+    endRenderSprite: () => null,
+    renderTexture: () => null,
+  };
+
   const domPlatform: ReplayPlatform<Inputs> = {
     getGetDevice: deviceCreator(
       audioContext,
@@ -411,11 +420,8 @@ export function renderCanvas<S>(
       platformOptions?.storage || getStorage(),
       platformOptions?.clipboard || getClipboard()
     ),
+    render: mutRender,
   };
-
-  const render: {
-    ref: ((textures: SpriteTextures) => void) | null;
-  } = { ref: null };
 
   updateDeviceSize();
 
@@ -442,7 +448,7 @@ export function renderCanvas<S>(
   document.addEventListener("keydown", onFirstInteraction, false);
   document.addEventListener(pointerDownEv, onFirstInteraction, false);
 
-  const { initTextures, getNextFrameTextures } = replayCore<S, Inputs>(
+  const { runNextFrame } = replayCore<S, Inputs>(
     domPlatform,
     {
       nativeSpriteMap,
@@ -453,10 +459,9 @@ export function renderCanvas<S>(
 
   let initTime: number | null = null;
 
-  function loop(textures: SpriteTextures) {
-    render.ref?.(textures);
+  function loop() {
     statsEnd?.();
-    window.requestAnimationFrame((time) => {
+    window.requestAnimationFrame(function newFrame(time) {
       if (isCleanedUp) {
         return;
       }
@@ -469,16 +474,14 @@ export function renderCanvas<S>(
         totalPageNotVisibleTime += time - lastPageNotVisibleTime;
       }
       lastTimeValue = time;
-      loop(
-        getNextFrameTextures(
-          time - initTime - totalPageNotVisibleTime,
-          resetInputs
-        )
-      );
+
+      runNextFrame(time - initTime - totalPageNotVisibleTime, resetInputs);
+
+      loop();
     });
   }
 
-  loop(initTextures);
+  loop();
 
   /**
    * Unloads the game and removes all loops and event listeners

--- a/packages/replay-web/src/size.ts
+++ b/packages/replay-web/src/size.ts
@@ -1,36 +1,6 @@
 import { GameSize, DeviceSize } from "@replay/core";
 import { Dimensions } from "./dimensions";
 
-// We use a variable we mutate so that we don't need to calculate the size every
-// frame - on window resize we simply mutate the value to update it.
-let deviceSize: DeviceSize | undefined;
-
-/**
- * Get the device size, use `setDeviceSize` to update the value.
- */
-export function getDeviceSize() {
-  return deviceSize;
-}
-
-/**
- * Update the device size. This mutates the value received from `getDeviceSize`.
- */
-export function setDeviceSize(
-  innerWidth: number,
-  innerHeight: number,
-  dimensions: Dimensions,
-  gameSize: GameSize
-) {
-  const newDeviceSize = calculateDeviceSize(
-    innerWidth,
-    innerHeight,
-    dimensions,
-    gameSize
-  );
-  deviceSize = newDeviceSize;
-  return newDeviceSize;
-}
-
 export function calculateDeviceSize(
   innerWidth: number,
   innerHeight: number,

--- a/packages/replay-web/src/timer.ts
+++ b/packages/replay-web/src/timer.ts
@@ -8,7 +8,7 @@ type Timer = {
   isPaused: boolean;
 };
 
-export function getTimer(): Device<{}>["timer"] {
+export function getTimer(): Device["timer"] {
   const timerMap: Record<string, Timer | undefined> = {};
 
   return {

--- a/website/docs/device.md
+++ b/website/docs/device.md
@@ -3,12 +3,13 @@ id: device
 title: Device
 ---
 
-The `device` parameter of the Sprite methods can be used to interact with the platform, like reading inputs and playing sound effects.
+The `device` and `getInputs` parameters of the Sprite methods can be used to interact with the platform, like getting mouse coordinates and playing sound effects.
 
 ```js
-  loop({ device }) {
+  loop({ device, getInputs }) {
+    const inputs = getInputs();
+
     const {
-      inputs,
       size,
       log,
       random,
@@ -30,9 +31,9 @@ The `device` parameter of the Sprite methods can be used to interact with the pl
 Functions like `log` and `random` replace `console.log` and `Math.random`. Using these ensures the game works across all platforms and tests (plus it keeps your Sprite methods pure).
 :::
 
-### `inputs`
+### `getInputs`
 
-An object of the device's input state. **The value depends on the platform your game is running on**. See [Platforms](web.md) for the values available.
+A function which returns an object of the device's input state. **The value depends on the platform your game is running on**. See [Platforms](web.md) for the values available.
 
 Platforms share similar input object shapes. For example, both the web and iOS platforms have a `pointer` field (relative to the Sprite's position):
 

--- a/website/docs/pure-sprites.md
+++ b/website/docs/pure-sprites.md
@@ -71,7 +71,7 @@ export const Player = makePureSprite<Props>({
 </TabItem>
 </Tabs>
 
-The Sprite object passed into `makePureSprite` must have the methods `render` and `shouldRerender` defined. `render` is similar to a regular Sprite, but with only a `props` and `size` parameter, and **can only return [Textures](textures.md) or other Pure Sprites**. Pure Sprites do not have state or access to the `device` parameter.
+The Sprite object passed into `makePureSprite` must have the methods `render` and `shouldRerender` defined. `render` is similar to a regular Sprite, but with only a `props` and `size` parameter, and **can only return [Textures](textures.md) or other Pure Sprites**. Pure Sprites do not have state or access to the `device` and `getInputs` parameters.
 
 `shouldRerender` is how Replay optimises your Sprite. Based on the last frame's props and the current frame's props, you must return a `boolean` of whether the Sprite needs to be redrawn. In our example above, if the `color` prop doesn't change, we don't need to call `render` again (since the return value will be the same). This caching can save time over many renders and improve your game's performance.
 

--- a/website/docs/sprites.md
+++ b/website/docs/sprites.md
@@ -216,6 +216,7 @@ All Sprite methods have the following parameters:
 
 - `props`: The props passed in by the parent Sprite.
 - `device`: The device object, see [Device](device.md).
+- `getInputs`: A function which return the current inputs as an object, see [Device](device.md).
 - `updateState`: A callback to update the `state` of the Sprite. Useful for asynchronous things like timers. Pass a function which takes the existing state and returns a new state. E.g:
    ```js
    updateState((prevState) => ({ ...prevState, playerX: 0 }));
@@ -227,7 +228,7 @@ All Sprite methods have the following parameters:
 Called on initial load of Sprite. Use this to run anything you need on setup. Returns the initial state.
 
 ```js
-  init({ props, device, updateState, preloadFiles, getState }) {
+  init({ props, device, getInputs, updateState, preloadFiles, getState }) {
     return { ... };
   },
 ```
@@ -249,7 +250,7 @@ Called on initial load of Sprite. Use this to run anything you need on setup. Re
 Called every frame of the game. Put your game logic here. Returns the next frame's state.
 
 ```js
-  loop({ props, state, device, updateState, getState }) {
+  loop({ props, state, device, getInputs, updateState, getState }) {
     return { ...state, ... };
   },
 ```
@@ -263,7 +264,7 @@ Called every frame of the game. Put your game logic here. Returns the next frame
 Called when the device renders to screen. Returns an array of Sprites to render.
 
 ```js
-  render({ props, state, device, updateState, getState, extrapolateFactor }) {
+  render({ props, state, device, getInputs, updateState, getState, extrapolateFactor }) {
     return [ ... ];
   },
 ```

--- a/website/docs/test.md
+++ b/website/docs/test.md
@@ -17,7 +17,7 @@ The `@replay/test` package is useful for writing tests in Jest for your Replay g
 - `sprite`: The Sprite you want to test called with its props, e.g. `Player(playerProps)`.
 - `gameProps`: The props defined for your top-level `Game`. This sets the device size during tests.
 - `options`: (Optional) An object with the following properties:
-  - `initInputs`: (Optional) The inputs your `device` returns. Match with the platforms you're targeting.
+  - `initInputs`: (Optional) The inputs `getInputs` returns. Match with the platforms you're targeting.
   - `mapInputCoordinates`: (Optional) A mapping function to adjust an input's (x, y) coordinate to its relative value within a Sprite. The [Web package](web.md) exports this for pointer values.
   - `initRandom`: (Optional) An array of numbers that `random()` will call, starting from index 0 and looping if it reaches the end. Allows for predictable randomness.
   - `size`: (Optional) Set the size parameter passed into Sprites.

--- a/website/docs/tutorial/10.md
+++ b/website/docs/tutorial/10.md
@@ -4,6 +4,6 @@ Let's draw a nice blue background for our bird to jump in, instead of the defaul
 
 We add a `t.rectangle` Texture as the _first_ Sprite returned in the `Level` Sprite `render` method. Sprites are rendered in the order they're returned, so this way our background will always be drawn at the back.
 
-We also want to fill the full view, not just the safe zone. To do this we need a rectangle the width and height of the view, plus the margins. The `device` parameter we accessed before to get `inputs` also has a `size` field just for this.
+We also want to fill the full view, not just the safe zone. To do this we need a rectangle the width and height of the view, plus the margins. Sprite methods also have a `device` parameter with a `size` field just for this.
 
 We could set a position for the rectangle through an `x` and `y` prop, but actually the default `x: 0, y: 0` position is exactly what we want. In Replay, the origin is directly in the center of the screen, and when you position a Sprite you're positioning its center point too. The `y` axis is also positive upwards.

--- a/website/docs/tutorial/8.md
+++ b/website/docs/tutorial/8.md
@@ -2,8 +2,6 @@
 
 It's time to have the bird jump when we click (or tap) the screen!
 
-Sprite methods like `loop` have a `device` parameter to interface with the platform we're running on.
-
-Within `device` there's a field `inputs` which contains an object of what inputs are being pressed in the current frame. We want to access `inputs.pointer` which has information about the mouse (or touch on mobile).
+Sprite methods like `loop` have a `getInputs` parameter which returns an object of what inputs are being pressed in the current frame. We want to access `inputs.pointer` which has information about the mouse (or touch on mobile).
 
 When the `pointer` has just been pressed (which only happens for one frame) we return a different value of the `birdGravity` state to update gravity, thus giving our bird a jump upwards. Give it a try!

--- a/website/src/tutorial/10/js/level.js
+++ b/website/src/tutorial/10/js/level.js
@@ -11,8 +11,8 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/10/ts/level.ts
+++ b/website/src/tutorial/10/ts/level.ts
@@ -18,8 +18,8 @@ export const Level = makeSprite<{}, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/11/js/level.js
+++ b/website/src/tutorial/11/js/level.js
@@ -11,8 +11,8 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/11/ts/level.ts
+++ b/website/src/tutorial/11/ts/level.ts
@@ -18,8 +18,8 @@ export const Level = makeSprite<{}, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/12/js/level.js
+++ b/website/src/tutorial/12/js/level.js
@@ -11,12 +11,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/12/ts/level.ts
+++ b/website/src/tutorial/12/ts/level.ts
@@ -22,12 +22,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/13/js/level.js
+++ b/website/src/tutorial/13/js/level.js
@@ -11,12 +11,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/13/js/menu.js
+++ b/website/src/tutorial/13/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/13/ts/level.ts
+++ b/website/src/tutorial/13/ts/level.ts
@@ -22,12 +22,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/13/ts/menu.ts
+++ b/website/src/tutorial/13/ts/menu.ts
@@ -7,8 +7,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/14/js/level.js
+++ b/website/src/tutorial/14/js/level.js
@@ -14,12 +14,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes } = state;
 

--- a/website/src/tutorial/14/js/menu.js
+++ b/website/src/tutorial/14/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/14/ts/level.ts
+++ b/website/src/tutorial/14/ts/level.ts
@@ -26,12 +26,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes } = state;
 
@@ -94,7 +94,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/14/ts/menu.ts
+++ b/website/src/tutorial/14/ts/menu.ts
@@ -7,8 +7,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/15/js/level.js
+++ b/website/src/tutorial/15/js/level.js
@@ -14,12 +14,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes } = state;
 

--- a/website/src/tutorial/15/js/menu.js
+++ b/website/src/tutorial/15/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/15/ts/level.ts
+++ b/website/src/tutorial/15/ts/level.ts
@@ -27,12 +27,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes } = state;
 
@@ -99,7 +99,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/15/ts/menu.ts
+++ b/website/src/tutorial/15/ts/menu.ts
@@ -7,8 +7,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/16/js/level.js
+++ b/website/src/tutorial/16/js/level.js
@@ -15,12 +15,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 

--- a/website/src/tutorial/16/js/menu.js
+++ b/website/src/tutorial/16/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/16/ts/level.ts
+++ b/website/src/tutorial/16/ts/level.ts
@@ -29,12 +29,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 
@@ -112,7 +112,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/16/ts/menu.ts
+++ b/website/src/tutorial/16/ts/menu.ts
@@ -7,8 +7,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/17/js/level.js
+++ b/website/src/tutorial/17/js/level.js
@@ -15,12 +15,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 

--- a/website/src/tutorial/17/js/menu.js
+++ b/website/src/tutorial/17/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/17/ts/level.ts
+++ b/website/src/tutorial/17/ts/level.ts
@@ -29,12 +29,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 
@@ -112,7 +112,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/17/ts/menu.ts
+++ b/website/src/tutorial/17/ts/menu.ts
@@ -8,8 +8,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/18/js/level.js
+++ b/website/src/tutorial/18/js/level.js
@@ -15,12 +15,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 

--- a/website/src/tutorial/18/js/menu.js
+++ b/website/src/tutorial/18/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/18/ts/level.ts
+++ b/website/src/tutorial/18/ts/level.ts
@@ -29,12 +29,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 
@@ -112,7 +112,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/18/ts/menu.ts
+++ b/website/src/tutorial/18/ts/menu.ts
@@ -8,8 +8,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/19/js/level.js
+++ b/website/src/tutorial/19/js/level.js
@@ -15,12 +15,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 

--- a/website/src/tutorial/19/js/menu.js
+++ b/website/src/tutorial/19/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/19/ts/level.ts
+++ b/website/src/tutorial/19/ts/level.ts
@@ -29,12 +29,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 
@@ -113,7 +113,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/19/ts/menu.ts
+++ b/website/src/tutorial/19/ts/menu.ts
@@ -8,8 +8,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/20/js/level.js
+++ b/website/src/tutorial/20/js/level.js
@@ -15,12 +15,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 

--- a/website/src/tutorial/20/js/menu.js
+++ b/website/src/tutorial/20/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/20/ts/level.ts
+++ b/website/src/tutorial/20/ts/level.ts
@@ -29,12 +29,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 
@@ -113,7 +113,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/20/ts/menu.ts
+++ b/website/src/tutorial/20/ts/menu.ts
@@ -8,8 +8,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/21/js/level.js
+++ b/website/src/tutorial/21/js/level.js
@@ -15,12 +15,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 

--- a/website/src/tutorial/21/js/menu.js
+++ b/website/src/tutorial/21/js/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/21/ts/level.ts
+++ b/website/src/tutorial/21/ts/level.ts
@@ -29,12 +29,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 
@@ -113,7 +113,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/21/ts/menu.ts
+++ b/website/src/tutorial/21/ts/menu.ts
@@ -8,8 +8,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/8/js/level.js
+++ b/website/src/tutorial/8/js/level.js
@@ -11,8 +11,8 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/8/ts/level.ts
+++ b/website/src/tutorial/8/ts/level.ts
@@ -18,8 +18,8 @@ export const Level = makeSprite<{}, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/9/js/level.js
+++ b/website/src/tutorial/9/js/level.js
@@ -11,8 +11,8 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/9/ts/level.ts
+++ b/website/src/tutorial/9/ts/level.ts
@@ -18,8 +18,8 @@ export const Level = makeSprite<{}, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ state, device }) {
-    const { inputs } = device;
+  loop({ state, getInputs }) {
+    const inputs = getInputs();
 
     let { birdGravity, birdY } = state;
 

--- a/website/src/tutorial/final/js/src/level.js
+++ b/website/src/tutorial/final/js/src/level.js
@@ -15,12 +15,12 @@ export const Level = makeSprite({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 

--- a/website/src/tutorial/final/js/src/menu.js
+++ b/website/src/tutorial/final/js/src/menu.js
@@ -1,8 +1,8 @@
 import { makeSprite, t } from "@replay/core";
 
 export const Menu = makeSprite({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();

--- a/website/src/tutorial/final/ts/src/level.ts
+++ b/website/src/tutorial/final/ts/src/level.ts
@@ -29,12 +29,12 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
     };
   },
 
-  loop({ props, state, device }) {
+  loop({ props, state, getInputs, device }) {
     if (props.paused) {
       return state;
     }
 
-    const { inputs } = device;
+    const inputs = getInputs();
 
     let { birdGravity, birdY, pipes, score } = state;
 
@@ -113,7 +113,7 @@ export const Level = makeSprite<LevelProps, LevelState, WebInputs | iOSInputs>({
   },
 });
 
-function newPipe(device: Device<{}>): PipeT {
+function newPipe(device: Device): PipeT {
   const height = device.size.height + device.size.heightMargin * 2;
   const randomY = (height - pipeGap * 2) * (device.random() - 0.5);
 

--- a/website/src/tutorial/final/ts/src/menu.ts
+++ b/website/src/tutorial/final/ts/src/menu.ts
@@ -8,8 +8,8 @@ type MenuProps = {
 };
 
 export const Menu = makeSprite<MenuProps, undefined, WebInputs | iOSInputs>({
-  render({ props, device }) {
-    const { inputs } = device;
+  render({ props, getInputs, device }) {
+    const inputs = getInputs();
 
     if (inputs.pointer.justReleased || inputs.keysJustPressed[" "]) {
       props.start();


### PR DESCRIPTION
Some improvements to memory usage and speed of replay-core. Note this has a **breaking API change**:

- `inputs` has been removed from `device` and replaced with `getInputs` in sprite methods.

Benchmarks results on my machine (node v12.20.1) show ~50% drop in memory usage per frame (less GC) and ~40% speedup:

```
Simple texture
new x 1,358 ops/sec ±1.25% (88 runs sampled) 1016 B / frame
previous x 1,084 ops/sec ±1.05% (89 runs sampled) 2256 B / frame
Fastest is new
Lowest memory is new

Nested Sprite
new x 791 ops/sec ±1.42% (87 runs sampled) 1840 B / frame
previous x 554 ops/sec ±2.50% (86 runs sampled) 4376 B / frame
Fastest is new
Lowest memory is new

Pure Sprite
new x 1,272 ops/sec ±1.78% (83 runs sampled) 840 B / frame
previous x 1,001 ops/sec ±1.45% (86 runs sampled) 2520 B / frame
Fastest is new
Lowest memory is new

Moving Sprite
new x 717 ops/sec ±1.11% (86 runs sampled) 1968 B / frame
previous x 510 ops/sec ±0.95% (88 runs sampled) 4496 B / frame
Fastest is new
Lowest memory is new

Sprite with input
new x 657 ops/sec ±1.46% (86 runs sampled) 2352 B / frame
previous x 530 ops/sec ±2.00% (86 runs sampled) 4440 B / frame
Fastest is new
Lowest memory is new

Sprites removed and created
new x 167 ops/sec ±1.40% (83 runs sampled) 11272 B / frame
previous x 134 ops/sec ±0.91% (75 runs sampled) 16872 B / frame
Fastest is new
Lowest memory is new

1000 textures
new x 3.15 ops/sec ±1.50% (12 runs sampled) 440896 B / frame
previous x 3.03 ops/sec ±1.03% (12 runs sampled) 478552 B / frame
Fastest is new
Lowest memory is new

1000 Sprites
new x 0.92 ops/sec ±1.46% (7 runs sampled) 1238920 B / frame
previous x 0.65 ops/sec ±1.73% (6 runs sampled) 2451096 B / frame
Fastest is new
Lowest memory is new

1000 Pure Sprites
new x 2.32 ops/sec ±1.81% (10 runs sampled) 200112 B / frame
previous x 1.98 ops/sec ±2.04% (9 runs sampled) 563728 B / frame
Fastest is new
Lowest memory is new

200 Nested Sprites
new x 9.11 ops/sec ±0.81% (27 runs sampled) 170728 B / frame
previous x 0.76 ops/sec ±4.23% (6 runs sampled) 3934192 B / frame
Fastest is new
Lowest memory is new
```