### PR TITLE
Duplicate Sprite ID in first frame

### DIFF
--- a/packages/replay-core/src/__tests__/replay-core.test.ts
+++ b/packages/replay-core/src/__tests__/replay-core.test.ts
@@ -26,6 +26,7 @@ import {
   DuplicateSpriteIdsGame,
   TestContextGame,
   TestContextErrorGame,
+  DuplicatePureSpriteIdsGame,
 } from "./utils";
 import { NativeSpriteUtils } from "../sprite";
 import { TextTexture, CircleTexture } from "../t";
@@ -1063,14 +1064,24 @@ test("Sprite unmounted before it loads", async () => {
 test("throws error on duplicate Sprites", () => {
   const { platform } = getTestPlatform();
 
-  const { runNextFrame } = replayCore(
-    platform,
-    nativeSpriteSettings,
-    DuplicateSpriteIdsGame(gameProps)
-  );
+  expect(() => {
+    replayCore(
+      platform,
+      nativeSpriteSettings,
+      DuplicateSpriteIdsGame(gameProps)
+    );
+  }).toThrowError("Duplicate Sprite id TestSprite");
+});
+
+test("throws error on duplicate Pure Sprites", () => {
+  const { platform } = getTestPlatform();
 
   expect(() => {
-    runNextFrame(1000 / 60, jest.fn());
+    replayCore(
+      platform,
+      nativeSpriteSettings,
+      DuplicatePureSpriteIdsGame(gameProps)
+    );
   }).toThrowError("Duplicate Sprite id TestSprite");
 });
 

--- a/packages/replay-core/src/__tests__/utils.ts
+++ b/packages/replay-core/src/__tests__/utils.ts
@@ -969,6 +969,48 @@ export const DuplicateSpriteIdsGame = makeSprite<GameProps>({
   },
 });
 
+export const DuplicatePureSpriteIdsGame = makeSprite<GameProps>({
+  render() {
+    return [
+      PureSprite({
+        id: "TestSprite",
+      }),
+    ];
+  },
+});
+
+const PureSprite = makePureSprite({
+  shouldRerender() {
+    return false;
+  },
+
+  render() {
+    return [
+      PureSpriteNested({
+        id: "TestSprite",
+      }),
+      PureSpriteNested({
+        id: "TestSprite",
+      }),
+    ];
+  },
+});
+
+const PureSpriteNested = makePureSprite({
+  shouldRerender() {
+    return false;
+  },
+
+  render() {
+    return [
+      t.circle({
+        radius: 5,
+        color: "red",
+      }),
+    ];
+  },
+});
+
 /// -- Test Pure Sprites
 
 export const PureSpriteGame = makeSprite<


### PR DESCRIPTION
Adds check for duplicate ids in the first frame of Sprites, and ensures checks are also made in Pure Sprites.