### PR TITLE
Remove onended when pause audio

### DIFF
--- a/packages/replay-web/src/device.ts
+++ b/packages/replay-web/src/device.ts
@@ -113,6 +113,7 @@ export function getAudio(
       },
       pause: () => {
         if (playState && !playState.isPaused) {
+          playState.sample.onended = null;
           playState.sample.stop();
           data.playState = {
             ...playState,


### PR DESCRIPTION
This avoids a bug where audio sometimes doesn't pause.