### PR TITLE
Add cleanup Sprite method

### DIFF
--- a/packages/replay-core/src/__tests__/replay-core.test.ts
+++ b/packages/replay-core/src/__tests__/replay-core.test.ts
@@ -922,6 +922,33 @@ test("loop and render order for callback prop change on low render FPS", () => {
   expect(resetInputs).toBeCalledTimes(9);
 });
 
+test("calls cleanup when unmounting Sprites", async () => {
+  const { platform, mutableTestDevice, mutInputs } = getTestPlatform();
+  const resetInputs = jest.fn();
+
+  const { runNextFrame } = replayCore(
+    platform,
+    nativeSpriteSettings,
+    AssetsGame(gameProps)
+  );
+
+  let time = 1;
+  const nextFrame = () => {
+    time += 1000 * (1 / 60);
+    runNextFrame(time, resetInputs);
+  };
+
+  await waitFrame();
+  nextFrame();
+
+  expect(mutableTestDevice.log).not.toHaveBeenCalledWith("cleanup");
+
+  mutInputs.ref.buttonPressed.show = false;
+  nextFrame();
+
+  expect(mutableTestDevice.log).toHaveBeenCalledWith("cleanup");
+});
+
 test("can preload and clear file assets", async () => {
   const {
     platform,

--- a/packages/replay-core/src/__tests__/utils.ts
+++ b/packages/replay-core/src/__tests__/utils.ts
@@ -924,6 +924,10 @@ const AssetsSprite = makeSprite<{
       }),
     ];
   },
+
+  cleanup({ device }) {
+    device.log("cleanup");
+  },
 });
 
 const NestedAssetsSprite = makeSprite<{

--- a/packages/replay-core/src/core.ts
+++ b/packages/replay-core/src/core.ts
@@ -291,6 +291,8 @@ function traverseCustomSpriteContainer<P, I>(
 
           recursiveSpriteCleanup(container.childContainers, containerGlobalId);
 
+          container.cleanup(getInputs);
+
           if (container.loadFilesPromise) {
             container.loadFilesPromise.then(() => {
               // Only cleanup once the initial load is complete
@@ -631,6 +633,13 @@ function createCustomSpriteContainer<P, S, I>(
 
       return sprites;
     },
+    cleanup(getInputs) {
+      spriteObj.cleanup?.({
+        state: this.state,
+        device: mutDevice,
+        getInputs,
+      });
+    },
   };
   return spriteContainer;
 }
@@ -698,6 +707,7 @@ type CustomSpriteContainer<P, S, I> = {
     time: number,
     contextValues: ContextValue[]
   ) => Sprite[];
+  cleanup: (getInputs: () => I) => void;
 };
 
 type PureCustomSpriteContainer<P> = {

--- a/packages/replay-core/src/sprite.ts
+++ b/packages/replay-core/src/sprite.ts
@@ -101,6 +101,15 @@ interface SpriteObjBase<P, S, I> {
     getContext: <T>(context: Context<T>) => T;
   }) => S;
 
+  /**
+   * Called on sprite unmount.
+   */
+  cleanup?: (params: {
+    state: Readonly<S>;
+    device: Device;
+    getInputs: () => I;
+  }) => void;
+
   // -- render methods
 
   /**

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -285,7 +285,7 @@ export function testSprite<P, S, I>(
         throw Error(`Audio file "${filename}" was not preloaded`);
       }
       const { data } = audioElements[filename];
-      if (typeof data === "object") {
+      if ("then" in data) {
         throw Error(
           `Audio file "${filename}" did not finish loading before it was used`
         );
@@ -370,8 +370,8 @@ export function testSprite<P, S, I>(
    */
   const resolvePromises = () => new Promise(setImmediate);
 
-  const audioElements: AssetMap<string> = {};
-  const imageElements: AssetMap<string> = {};
+  const audioElements: AssetMap<Record<string, string>> = {};
+  const imageElements: AssetMap<Record<string, string>> = {};
 
   type Pos = { x: number; y: number; rotation: number };
   /**
@@ -395,12 +395,12 @@ export function testSprite<P, S, I>(
         imageElements,
         loadAudioFile: (fileName) => {
           return Promise.resolve().then(() => {
-            return `audioData-${fileName}`;
+            return { [fileName]: "*audioData*" };
           });
         },
         loadImageFile: (fileName) => {
           return Promise.resolve().then(() => {
-            return `imageData-${fileName}`;
+            return { [fileName]: "*imageData*" };
           });
         },
         cleanupAudioFile: () => null,
@@ -438,7 +438,7 @@ export function testSprite<P, S, I>(
           if (!imageElement) {
             throw Error(`Image file "${fileName}" was not preloaded`);
           }
-          if (typeof imageElement.data === "object") {
+          if ("then" in imageElement.data) {
             throw Error(
               `Image file "${fileName}" did not finish loading before it was used`
             );

--- a/website/docs/sprites.md
+++ b/website/docs/sprites.md
@@ -286,3 +286,13 @@ An alternative render method run for large screens. See [Game Size](game-size.md
 ### `renderPXL`
 
 An alternative render method run for large screens if the device is in portrait. See [Game Size](game-size.md) for more.
+
+### `cleanup`
+
+Called when Sprite is removed. Useful for cleaning up any external libraries stored in state.
+
+```js
+  cleanup({ state, device, getInputs }) {
+    // Cleanup
+  },
+```


### PR DESCRIPTION
The `cleanup` method is called when a Sprite is unmounted. It's not required for vanilla Replay, but if you're using some external libraries which need cleaning up it's useful.