### PR TITLE
Fix web audio error on older Safari

### DIFF
--- a/packages/replay-web/src/device.ts
+++ b/packages/replay-web/src/device.ts
@@ -79,7 +79,12 @@ export function getAudio(
         const alreadyPlayedTime =
           fromPosition ?? getAudioPosition(audioContext, playState);
 
-        sampleSource.start(undefined, alreadyPlayedTime);
+        try {
+          sampleSource.start(undefined, alreadyPlayedTime);
+        } catch (_) {
+          // Older versions of Safari randomly throw errors
+          return;
+        }
         sampleSource.loop = loop;
         sampleSource.onended = () => {
           if (!audioElements[fileName]) return;


### PR DESCRIPTION
Ideally we shouldn't need this, but I have seen it on iOS 12 (and possibly iOS 13, need to confirm). Latest iOS doesn't have this problem.