### PR TITLE
Swift: Avoid WebView crashes on relaunch

### DIFF
--- a/packages/replay-swift/Replay/Sources/Replay/ReplayWebView.swift
+++ b/packages/replay-swift/Replay/Sources/Replay/ReplayWebView.swift
@@ -19,6 +19,8 @@ public class ReplayWebView: WKWebView {
 class ReplayWebViewManager: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNavigationDelegate {
     let webConfiguration = WKWebViewConfiguration()
     var webView: ReplayWebView!
+    var userStyles: String
+    var customGameJsString: String?
     let alerter = ReplayAlerter()
     let onJsCallback: (String) -> Void // userland
     let onLogCallback: (String) -> Void // for testing
@@ -32,6 +34,8 @@ class ReplayWebViewManager: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNa
     ) {
         self.onLogCallback = onLogCallback
         self.onJsCallback = onJsCallback
+        self.userStyles = userStyles
+        self.customGameJsString = customGameJsString
         super.init()
         
         let contentController = WKUserContentController()
@@ -56,6 +60,10 @@ class ReplayWebViewManager: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNa
         longPress.minimumPressDuration = 0.1
         webView.addGestureRecognizer(longPress)
         
+        loadGame()
+    }
+    
+    func loadGame() {
         // Load in game
         var gameJsString = ""
         
@@ -118,7 +126,10 @@ class ReplayWebViewManager: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNa
     }
     
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        fatalError("Web view terminated. This may be caused by your game using up too much memory.")
+        print("Web view terminated, restarting. This may be caused by your game using up too much memory.")
+        
+        // Reload
+        loadGame()
     }
     
     func handleInternalMessage(message: String) {

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -489,6 +489,13 @@ export function renderCanvas<S>(
         if (initTime === null) {
           initTime = time - 1 / 60;
         }
+
+        // Wait until visible before running to avoid bad timestamps
+        if (!isPageVisible) {
+          loop();
+          return;
+        }
+
         if (needsToUpdateNotVisibleTime) {
           needsToUpdateNotVisibleTime = false;
           totalPageNotVisibleTime += time - lastPageNotVisibleTime;


### PR DESCRIPTION
- Reload the WebView when memory usage forces it to close. This crash often happens on app relaunch so this should make it less obvious.
- Avoid timestamp bug of `loop` being called just before page is visible (and giving uncompensated time value). This was causing the game to freeze a long time when minimised and reopened.