### PR TITLE
Swift: Allow overriding JS crashes

### DIFF
--- a/packages/replay-swift/Replay/Sources/Replay/ReplayViewController.swift
+++ b/packages/replay-swift/Replay/Sources/Replay/ReplayViewController.swift
@@ -8,10 +8,11 @@ public class ReplayViewController: UIViewController {
         hideStatusBar: Bool = true,
         userStyles: String = "",
         jsRun: String = "renderCanvas.run();",
-        onJsCallback: @escaping (String) -> Void = {_ in }
+        onJsCallback: @escaping (String) -> Void = {_ in },
+        onJsCrash: @escaping (String) -> Void = {message in fatalError(message) }
     ) {
         self.hideStatusBar = hideStatusBar
-        self.webView = ReplayWebViewManager(userStyles: userStyles, jsRun: jsRun, onJsCallback: onJsCallback).webView
+        self.webView = ReplayWebViewManager(userStyles: userStyles, jsRun: jsRun, onJsCallback: onJsCallback, onJsCrash: onJsCrash).webView
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/packages/replay-swift/Replay/Sources/Replay/ReplayWebView.swift
+++ b/packages/replay-swift/Replay/Sources/Replay/ReplayWebView.swift
@@ -26,6 +26,7 @@ class ReplayWebViewManager: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNa
     let alerter = ReplayAlerter()
     let onJsCallback: (String) -> Void // userland
     let onLogCallback: (String) -> Void // for testing
+    let onJsCrash: (String) -> Void
     let internalMessageKey = "__internalReplay"
     
     init(
@@ -33,13 +34,15 @@ class ReplayWebViewManager: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNa
         userStyles: String,
         jsRun: String,
         onLogCallback: @escaping (String) -> Void = {_ in },
-        onJsCallback: @escaping (String) -> Void
+        onJsCallback: @escaping (String) -> Void,
+        onJsCrash: @escaping (String) -> Void
     ) {
         self.onLogCallback = onLogCallback
         self.onJsCallback = onJsCallback
         self.userStyles = userStyles
         self.jsRun = jsRun
         self.customGameJsString = customGameJsString
+        self.onJsCrash = onJsCrash
         super.init()
         
         let contentController = WKUserContentController()
@@ -106,7 +109,7 @@ class ReplayWebViewManager: NSObject, WKScriptMessageHandler, WKUIDelegate, WKNa
         let messageBody = "\(message.body)"
         switch message.name {
         case ERROR:
-            fatalError(messageBody)
+            onJsCrash(messageBody)
         case CONSOLE_LOG:
             onLogCallback(messageBody)
             if #available(iOS 14.0, *) {


### PR DESCRIPTION
Can be useful for displaying error message or logging crashes.