### PR TITLE
Add property to set global volume

### DIFF
--- a/packages/replay-core/src/__benchmarks__/utils.ts
+++ b/packages/replay-core/src/__benchmarks__/utils.ts
@@ -85,6 +85,10 @@ function getBenchmarkPlatform() {
       get: () => 1,
       set: jest.fn(),
     },
+    globalAudio: {
+      volume: 1,
+      setVolume: jest.fn(),
+    },
     now: () => new Date(Date.UTC(1995, 12, 17, 3, 24, 0)),
     audio: () => ({
       getPosition: () => 50,

--- a/packages/replay-core/src/__tests__/utils.ts
+++ b/packages/replay-core/src/__tests__/utils.ts
@@ -185,6 +185,10 @@ export function getTestPlatform(customSize?: DeviceSize) {
     },
     now: () => new Date(Date.UTC(1995, 12, 17, 3, 24, 0)),
     audio: () => audio,
+    globalAudio: {
+      volume: 1,
+      setVolume: jest.fn(),
+    },
     assetUtils: {
       imageElements: {},
       audioElements: {},

--- a/packages/replay-core/src/device.ts
+++ b/packages/replay-core/src/device.ts
@@ -88,6 +88,11 @@ export interface Device {
     getDuration: () => number;
   };
 
+  globalAudio: {
+    volume: number;
+    setVolume: (volume: number) => void;
+  };
+
   /**
    * Make network calls
    */

--- a/packages/replay-test/src/index.ts
+++ b/packages/replay-test/src/index.ts
@@ -405,6 +405,10 @@ export function testSprite<P, S, I>(
         get: () => 1,
         set: jest.fn(),
       },
+      globalAudio: {
+        volume: 1,
+        setVolume: jest.fn(),
+      },
       audio: audioFn,
       assetUtils: {
         audioElements,

--- a/packages/replay-web/jest-setup.js
+++ b/packages/replay-web/jest-setup.js
@@ -49,6 +49,7 @@ Object.defineProperty(window, "AudioContext", {
       connect: jest.fn,
       gain: {
         value: 1,
+        setValueAtTime: jest.fn(),
       },
     })),
   })),

--- a/packages/replay-web/src/__tests__/device.test.ts
+++ b/packages/replay-web/src/__tests__/device.test.ts
@@ -246,6 +246,7 @@ test("Can play audio, pause and get position", async () => {
     sample: expect.any(Object),
     playTime: 5.016,
     gainNode: expect.any(Object),
+    volume: 1,
   });
 
   clickPointer(102, 0);

--- a/website/docs/device.md
+++ b/website/docs/device.md
@@ -16,6 +16,7 @@ The `device` and `getInputs` parameters of the Sprite methods can be used to int
       timer,
       now,
       audio,
+      globalAudio,
       network,
       storage,
       alert,
@@ -210,6 +211,25 @@ Get the volume of the sound. 1 is maximum, 0 is muted.
 ```js
 const volume = mySound.getVolume();
 ```
+
+### `globalAudio`
+
+#### `volume`
+
+Returns the global volume as a number `0 - 1`.
+
+```js
+const volume = globalAudio.volume;
+```
+
+#### `setVolume(volume)`
+
+Set the global volume, between `0 - 1`. This value is automatically saved to local storage.
+
+```js
+globalAudio.setVolume(0.5);
+`````
+
 
 ### `network`
 


### PR DESCRIPTION
Provides a `globalAudio.volume` and `globalAudio.setVolume` in `device` to control the global volume level. Makes it easier for games to implement a volume slider.