### PR TITLE
Fix docs with respect to nativeSpriteMap mapping for TextInput

### DIFF
--- a/website/docs/text-input.md
+++ b/website/docs/text-input.md
@@ -34,7 +34,7 @@ const MySprite = makeSprite({
 import { TextInputWeb } from "@replay/text-input";
 
 export const options = {
-  { TextInput: TextInputWeb }
+  nativeSpriteMap: { TextInput: TextInputWeb }
 };
 ```
 


### PR DESCRIPTION
This quick fix helps update the docs regarding `TextInput` so that `nativeSpriteMap` is reflected as the key for which the existing map should be the value.