### PR TITLE
Web: Fix pausing game loops for alert

### DIFF
--- a/packages/replay-core/src/device.ts
+++ b/packages/replay-core/src/device.ts
@@ -118,13 +118,11 @@ export interface Device {
 
   alert: {
     /**
-     * An alert dialog with an OK button. Game loop will be paused on some
-     * platforms.
+     * An alert dialog with an OK button.
      */
     ok: (message: string, onResponse?: () => void) => void;
     /**
-     * An alert dialog with an OK and cancel button. Game loop will be paused on
-     * some platforms.
+     * An alert dialog with an OK and cancel button.
      */
     okCancel: (message: string, onResponse: (wasOk: boolean) => void) => void;
   };

--- a/packages/replay-web/src/index.ts
+++ b/packages/replay-web/src/index.ts
@@ -544,7 +544,23 @@ export function renderCanvas<S>(
       gameSprite.props.size
     ),
     assetUtils,
-    platformOptions?.device || {},
+    platformOptions?.device || {
+      // Pause game loop on sync alerts
+      alert: {
+        ok: (message, onResponse) => {
+          lastPageNotVisibleTime = lastTimeValue;
+          alert(message);
+          needsToUpdateNotVisibleTime = true;
+          onResponse?.();
+        },
+        okCancel: (message, onResponse) => {
+          lastPageNotVisibleTime = lastTimeValue;
+          const wasOk = confirm(message);
+          needsToUpdateNotVisibleTime = true;
+          onResponse(wasOk);
+        },
+      },
+    },
     mutResolution
   );
 


### PR DESCRIPTION
For replay-web, fixes an issue that holds up the game loop on alerts (and then time jumps when dismissed).